### PR TITLE
Isi 391 GitHub pipelines

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Advance Security Compliance Action
-        uses: GeekMasher/advanced-security-compliance@v1.6
+        uses: GeekMasher/advanced-security-compliance@v1.7.0
         with:
           policy: GeekMasher/security-queries
           policy-path: policies/default.yml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Advance Security Compliance Action
         uses: GeekMasher/advanced-security-compliance@v1.6


### PR DESCRIPTION
Version von Action checkout auf v3 angehoben, da nodejs 12 deprecated ist (siehe [hier](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)) und die Pipeline nodejs 16 verwendet (https://github.com/actions/checkout). 

Version von Action GeekMasher/advanced-security-compliance auf 1.7.0 angehoben, da 1.6 nicht mehr unterstützt wird. Siehe hier: https://github.com/GeekMasher/advanced-security-compliance

Siehe auch Pull Request https://github.com/it-at-m/isi-backend/pull/6