### PR TITLE
ISI-553 Fix Bug Rendern der gewählten Flurstücke bei Formularwechsel

### DIFF
--- a/frontend/src/components/common/Verortung.vue
+++ b/frontend/src/components/common/Verortung.vue
@@ -103,6 +103,10 @@ export default class Verortung extends Mixins(GeodataEaiApiRequestMixin, SaveLea
    */
   private selectedFlurstuecke: Map<string, FlurstueckDto> = new Map<string, FlurstueckDto>();
 
+  mounted(): void {
+    this.onVerortungModelChanged();
+  }
+
   get coordinate(): LatLngLiteral | undefined {
     const lat = this.lookAt?.coordinate?.latitude;
     const lng = this.lookAt?.coordinate?.longitude;

--- a/frontend/src/components/map/CityMap.vue
+++ b/frontend/src/components/map/CityMap.vue
@@ -22,7 +22,6 @@
         :base-url="getGeoUrl('WMS_Stadtkarte')"
         layers="Hintergrund"
         format="image/png"
-        layer-type="base"
         :visible="true"
       />
       <!-- Die Overlay-Layer der Karte. Es können beliebig viele von ihnen zur selben Zeit sichtbar sein, da sie nur spezifische Merkmale darstellen sollen. -->


### PR DESCRIPTION
**Description**

* Das Übergeben der Feature welche die Flurstücke repräsentieren wird neben dem Watcher auf das Verortungsobjekt auch beim Mounten des Formulars  gemacht.

**Reference**

ISI-553
