### PR TITLE
ISI-621 Bearbeiten von Bauvorhaben als Abfrageersteller einschränken

### DIFF
--- a/frontend/src/components/bauvorhaben/BauvorhabenForm.vue
+++ b/frontend/src/components/bauvorhaben/BauvorhabenForm.vue
@@ -229,7 +229,6 @@ import FieldGroupCard from "@/components/common/FieldGroupCard.vue";
 import NumField from "@/components/common/NumField.vue";
 import TriSwitch from "@/components/common/TriSwitch.vue";
 import SaveLeaveMixin from "@/mixins/SaveLeaveMixin";
-import AdresseComponent from "@/components/common/AdresseComponent.vue";
 import { VerortungContext } from "@/components/common/Verortung.vue";
 import SecurityMixin from "@/mixins/security/SecurityMixin";
 
@@ -245,7 +244,6 @@ export default class BauvorhabenForm extends Mixins(
   FieldPrefixesSuffixes,
   FieldValidationRulesMixin,
   SaveLeaveMixin,
-  AdresseComponent,
   SecurityMixin
 ) {
   @VModel({ type: BauvorhabenModel })

--- a/frontend/src/components/bauvorhaben/BauvorhabenForm.vue
+++ b/frontend/src/components/bauvorhaben/BauvorhabenForm.vue
@@ -12,6 +12,7 @@
             :rules="[fieldValidationRules.pflichtfeld]"
             maxlength="255"
             validate-on-blur
+            :disabled="!isEditable"
             @input="formChanged"
           >
             <template #label> Eigentümer <span class="secondary--text">*</span> </template>
@@ -27,6 +28,7 @@
             label="Grundstücksgröße"
             :suffix="fieldPrefixesSuffixes.squareMeter"
             required
+            :disabled="!isEditable"
           />
         </v-col>
       </v-row>
@@ -42,6 +44,7 @@
             item-value="key"
             item-text="value"
             :rules="[fieldValidationRules.pflichtfeld, fieldValidationRules.notUnspecified]"
+            :disabled="!isEditable"
             @change="formChanged"
           >
             <template #label> Stand des Vorhabens <span class="secondary--text">*</span> </template>
@@ -57,6 +60,7 @@
             :rules="[fieldValidationRules.pflichtfeld]"
             maxlength="255"
             validate-on-blur
+            :disabled="!isEditable"
             @input="formChanged"
           >
             <template #label> Bauvorhabennummer <span class="secondary--text">*</span> </template>
@@ -69,6 +73,7 @@
       :adresse-prop.sync="bauvorhaben.adresse"
       :allgemeine-ortsangabe-prop.sync="bauvorhaben.allgemeineOrtsangabe"
       :show-in-information-list-prop="true"
+      :is-editable-prop="isEditable"
     />
     <verortung
       id="verortung_component"
@@ -86,6 +91,7 @@
             item-value="key"
             item-text="value"
             :rules="[fieldValidationRules.pflichtfeld, fieldValidationRules.notUnspecified]"
+            :disabled="!isEditable"
             @change="formChanged"
           >
             <template #label> Planungsrecht <span class="secondary--text">*</span> </template>
@@ -103,6 +109,7 @@
             multiple
             chips
             :rules="[fieldValidationRules.pflichtfeldMehrfachauswahl, fieldValidationRules.notUnspecified]"
+            :disabled="!isEditable"
             @input="formChanged"
           >
             <template #label>
@@ -122,6 +129,7 @@
             v-model="bauvorhaben.bebauungsplannummer"
             label="Bebauungsplannummer"
             maxlength="255"
+            :disabled="!isEditable"
             @input="formChanged"
           />
         </v-col>
@@ -134,6 +142,7 @@
             v-model="bauvorhaben.fisNummer"
             label="FIS-Nummer"
             maxlength="255"
+            :disabled="!isEditable"
             @input="formChanged"
           />
         </v-col>
@@ -147,6 +156,7 @@
             rows="1"
             auto-grow
             maxlength="255"
+            :disabled="!isEditable"
             @input="formChanged"
           />
         </v-col>
@@ -159,6 +169,7 @@
             id="bauvorhaben_dokumente_component"
             v-model="bauvorhaben.dokumente"
             :name-root-folder="nameRootFolder"
+            :is-dokumente-editable="isEditable"
           />
         </v-col>
       </v-row>
@@ -175,6 +186,7 @@
             off-text="Nein"
             on-text="Ja"
             :rules="[fieldValidationRules.notUnspecified]"
+            :disabled="!isEditable"
           >
             <template #label> SoBoN-relevant <span class="secondary--text">*</span> </template>
           </tri-switch>
@@ -192,6 +204,7 @@
               item-value="key"
               item-text="value"
               :rules="[fieldValidationRules.pflichtfeld]"
+              :disabled="!isEditable"
               @change="formChanged"
             >
               <template #label>
@@ -206,7 +219,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, VModel, Watch } from "vue-property-decorator";
+import { Component, Mixins, Prop, VModel, Watch } from "vue-property-decorator";
 import { LookupEntryDto, UncertainBoolean } from "@/api/api-client/isi-backend";
 import FieldValidationRulesMixin from "@/mixins/validation/FieldValidationRulesMixin";
 import FieldPrefixesSuffixes from "@/mixins/FieldPrefixesSuffixes";
@@ -218,6 +231,7 @@ import TriSwitch from "@/components/common/TriSwitch.vue";
 import SaveLeaveMixin from "@/mixins/SaveLeaveMixin";
 import AdresseComponent from "@/components/common/AdresseComponent.vue";
 import { VerortungContext } from "@/components/common/Verortung.vue";
+import SecurityMixin from "@/mixins/security/SecurityMixin";
 
 @Component({
   computed: {
@@ -231,7 +245,8 @@ export default class BauvorhabenForm extends Mixins(
   FieldPrefixesSuffixes,
   FieldValidationRulesMixin,
   SaveLeaveMixin,
-  AdresseComponent
+  AdresseComponent,
+  SecurityMixin
 ) {
   @VModel({ type: BauvorhabenModel })
   bauvorhaben!: BauvorhabenModel;
@@ -245,6 +260,9 @@ export default class BauvorhabenForm extends Mixins(
   private nameRootFolder = "bauvorhaben";
 
   private allgemeineInfoCardTitle = "Allgemeine Informationen zum Bauvorhaben";
+
+  @Prop({ type: Boolean, default: false })
+  private readonly isEditable!: boolean;
 
   get standVorhabenList(): LookupEntryDto[] {
     return this.$store.getters["lookup/standVorhaben"];

--- a/frontend/src/views/Bauvorhaben.vue
+++ b/frontend/src/views/Bauvorhaben.vue
@@ -11,6 +11,7 @@
                 :rules="[fieldValidationRules.pflichtfeld]"
                 maxlength="255"
                 validate-on-blur
+                :disabled="!isEditable"
                 @input="formChanged"
               >
                 <template #label> Name des Bauvorhabens <span class="secondary--text">*</span> </template>
@@ -33,6 +34,7 @@
           color="primary"
           elevation="1"
           width="200px"
+          :disabled="!isEditable"
           @click="deleteDialogOpen = true"
           v-text="'Löschen'"
         />
@@ -43,6 +45,7 @@
           color="primary"
           elevation="1"
           width="200px"
+          :disabled="!isEditable"
           @click="dataTransferDialogOpen = true"
           v-text="'Datenübernahme'"
         />
@@ -59,7 +62,7 @@
           elevation="1"
           class="text-wrap mt-2 px-1"
           style="width: 200px"
-          :disabled="(!isNew && !isDirty()) || containsNotAllowedDokument(bauvorhaben.dokumente)"
+          :disabled="(!isNew && !isDirty()) || containsNotAllowedDokument(bauvorhaben.dokumente) || !isEditable"
           @click="validateAndProceed()"
           v-text="isNew ? 'Speichern' : 'Aktualisieren'"
         />
@@ -125,6 +128,7 @@ import BauvorhabenForm from "@/components/bauvorhaben/BauvorhabenForm.vue";
 import BauvorhabenDataTransferDialog from "@/components/bauvorhaben/BauvorhabenDataTransferDialog.vue";
 import { InfrastrukturabfrageDto } from "@/api/api-client/isi-backend";
 import { containsNotAllowedDokument } from "@/utils/DokumenteUtil";
+import SecurityMixin from "@/mixins/security/SecurityMixin";
 
 @Component({
   methods: { containsNotAllowedDokument },
@@ -142,7 +146,8 @@ export default class Bauvorhaben extends Mixins(
   ValidatorMixin,
   BauvorhabenApiRequestMixin,
   SaveLeaveMixin,
-  InformationListMixin
+  InformationListMixin,
+  SecurityMixin
 ) {
   private bauvorhaben = new BauvorhabenModel(createBauvorhabenDto());
 
@@ -166,6 +171,10 @@ export default class Bauvorhaben extends Mixins(
     if (!_.isNil(bauvorhabenFromStore)) {
       this.bauvorhaben = new BauvorhabenModel(_.cloneDeep(bauvorhabenFromStore));
     }
+  }
+
+  get isEditable(): boolean {
+    return this.isRoleAdminOrSachbearbeitung();
   }
 
   /**

--- a/frontend/src/views/Bauvorhaben.vue
+++ b/frontend/src/views/Bauvorhaben.vue
@@ -24,6 +24,7 @@
         <bauvorhaben-form
           id="bauvorhaben_bauvorhabenForm_component"
           v-model="bauvorhaben"
+          :is-editable="isEditable"
         />
       </template>
       <template #information>

--- a/frontend/src/views/BauvorhabenUebersicht.vue
+++ b/frontend/src/views/BauvorhabenUebersicht.vue
@@ -87,8 +87,9 @@ export default class BauvorhabenUebersicht extends Mixins(BauvorhabenApiRequestM
 
   private options = false;
 
-  @Prop({ type: Boolean, default: false })
-  private readonly isEditable!: boolean;
+  get isEditable(): boolean {
+    return this.isRoleAdminOrSachbearbeitung();
+  }
 
   get bauvorhabenList(): BauvorhabenDto[] {
     const list = this.$store.getters["search/resultBauvorhaben"];

--- a/frontend/src/views/BauvorhabenUebersicht.vue
+++ b/frontend/src/views/BauvorhabenUebersicht.vue
@@ -56,6 +56,7 @@
               fab
               x-large
               color="secondary"
+              :disabled="!isEditable"
               v-on="on"
               @click="createBauvorhaben()"
             >
@@ -71,19 +72,23 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins } from "vue-property-decorator";
+import { Component, Mixins, Prop } from "vue-property-decorator";
 import router from "@/router";
 import DefaultLayout from "@/components/DefaultLayout.vue";
 import { BauvorhabenDto, LookupEntryDto } from "@/api/api-client/isi-backend";
 import BauvorhabenApiRequestMixin from "@/mixins/requests/BauvorhabenApiRequestMixin";
+import SecurityMixin from "@/mixins/security/SecurityMixin";
 
 @Component({
   components: { DefaultLayout },
 })
-export default class BauvorhabenUebersicht extends Mixins(BauvorhabenApiRequestMixin) {
+export default class BauvorhabenUebersicht extends Mixins(BauvorhabenApiRequestMixin, SecurityMixin) {
   private fetchSuccess: boolean | null = null;
 
   private options = false;
+
+  @Prop({ type: Boolean, default: false })
+  private readonly isEditable!: boolean;
 
   get bauvorhabenList(): BauvorhabenDto[] {
     const list = this.$store.getters["search/resultBauvorhaben"];


### PR DESCRIPTION
Durch den Bugfix werden für die Rolle "Abfrageersteller" die Rechte (Erstellen, Löschen und Speichern/Aktuallisieren) eines Bauvorhabens verboten/eingeschränkt, indem die entsprechenden Elemente wie z.B. Löschen/Speichern-Buttons ausgegraut werden und der Plus-Button zum erstellen eines neuen Bauvorhabens nicht mehr erscheint. Auch werden die Anzeigefelder in dem Bauvorhabenformular ausgegraut. Bestehende Bauvorhaben können weiterhin angesehen werden. Die Rollen "Sachbearbeiter" und "Admin" können weiterhin uneingeschränkt die Bauvorhaben zusätzlich Löschen und Speichern.

Issues: ISI-621
