### PR TITLE
ISI-621 Dropdown fuer Dokumentart gefixt

### DIFF
--- a/frontend/src/components/common/dokumente/DokumenteListe.vue
+++ b/frontend/src/components/common/dokumente/DokumenteListe.vue
@@ -75,6 +75,7 @@
                         item-text="value"
                         :rules="[fieldValidationRules.pflichtfeld, fieldValidationRules.notUnspecified]"
                         :readonly="isDokumentNotAllowed(item)"
+                        :disabled="!isDokumenteEditable"
                         @change="formChanged"
                       >
                         <template #label> Dokumentart <span class="secondary--text">*</span> </template>


### PR DESCRIPTION
Hierbei wird das Problem gefixt, dass man als Abfrageersteller weiterhin im Frontend die Dokumentart in einem Bauvorhaben ändern konnte.

Issues ISI-621
