### PR TITLE
ISI-686: Korrektur CNAME beim Publizieren der Github Page

### DIFF
--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -4,6 +4,9 @@ name: release docs
 
 # Controls when the workflow will run
 on:
+  push:
+    branches:
+      - 'ISI-686-GithubPages'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
@@ -43,3 +46,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/dist
+          cname: isi.oss.muenchen.de
+

--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -4,9 +4,6 @@ name: release docs
 
 # Controls when the workflow will run
 on:
-  push:
-    branches:
-      - 'ISI-686-GithubPages'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-isi.oss.muenchen.de


### PR DESCRIPTION
**Description**

'cname: isi.oss.muenchen.de' beim Publizieren der Github Pages hinzugefügt

**Reference**

Issues ISI-686
