### PR TITLE
Bug Nutzer kann Abfrage Löschen  Popup öffnen

### DIFF
--- a/frontend/src/mixins/security/AbfrageSecurityMixin.ts
+++ b/frontend/src/mixins/security/AbfrageSecurityMixin.ts
@@ -35,6 +35,7 @@ export default class AbfrageSecurityMixin extends Mixins(SecurityMixin) {
   }
 
   public isEditableByAdmin(): boolean {
-    return this.isRoleAdmin();
+    const abfrage: InfrastrukturabfrageModel = this.$store.getters["search/selectedAbfrage"];
+    return !_.isNil(abfrage) ? this.isRoleAdmin() : false;
   }
 }

--- a/frontend/src/mixins/security/AbfrageSecurityMixin.ts
+++ b/frontend/src/mixins/security/AbfrageSecurityMixin.ts
@@ -33,4 +33,8 @@ export default class AbfrageSecurityMixin extends Mixins(SecurityMixin) {
           abfrage.abfrage?.statusAbfrage === StatusAbfrage.InBearbeitungSachbearbeitung
       : false;
   }
+
+  public isEditableByAdmin(): boolean {
+    return this.isRoleAdmin();
+  }
 }

--- a/frontend/src/views/Abfrage.vue
+++ b/frontend/src/views/Abfrage.vue
@@ -180,7 +180,7 @@
           color="primary"
           elevation="1"
           style="width: 200px"
-          :disabled="disableDeleteButton()"
+          :disabled="!isDeleteable()"
           @click="deleteAbfrage()"
           v-text="'Löschen'"
         />
@@ -397,14 +397,8 @@ export default class Abfrage extends Mixins(
     this.isDeleteDialogAbfrageOpen = true;
   }
 
-  private disableDeleteButton(): boolean {
-    if (this.isEditableByAdmin()) {
-      return false;
-    } else if (this.isEditableByAbfrageerstellung()) {
-      return false;
-    } else {
-      return true;
-    }
+  private isDeleteable(): boolean {
+    return this.isEditableByAbfrageerstellung() || this.isEditableByAdmin();
   }
 
   private statusUebergang(transition: TransitionDto): void {

--- a/frontend/src/views/Abfrage.vue
+++ b/frontend/src/views/Abfrage.vue
@@ -180,6 +180,7 @@
           color="primary"
           elevation="1"
           style="width: 200px"
+          :disabled="disableDeleteButton()"
           @click="deleteAbfrage()"
           v-text="'Löschen'"
         />
@@ -394,6 +395,16 @@ export default class Abfrage extends Mixins(
 
   private deleteAbfrage(): void {
     this.isDeleteDialogAbfrageOpen = true;
+  }
+
+  private disableDeleteButton(): boolean {
+    if (this.isEditableByAdmin()) {
+      return false;
+    } else if (this.isEditableByAbfrageerstellung()) {
+      return false;
+    } else {
+      return true;
+    }
   }
 
   private statusUebergang(transition: TransitionDto): void {


### PR DESCRIPTION
**Description**

In dieser Story wurde der Bug gefixt das Nutzer auf den Button "Löschen" drücken können und dann das Popup sich öffnet (im Backend wird das fehlende Recht aufgefangen aber trotzdem verwirrend). 

Nach Absprache mit dem PO soll das verhalten folgendermaßen sein:

Admin kann unabhängig vom Status Abfragen löschen
Abfrageersteller nur im Status "Angelegt" 
Nutzer und Sachbearbeiter gar nicht

**Reference**

Issues #761
