### PR TITLE
ISI-646-Darstellung von nicht interaktiven Geodatenlayern auf der Karte

### DIFF
--- a/frontend/src/components/map/CityMap.vue
+++ b/frontend/src/components/map/CityMap.vue
@@ -169,9 +169,8 @@ export default class CityMap extends Vue {
   /**
    * Mappt Overlay-Namen zur kommaseparierten Liste ihrer Layers.
    */
-  private overlays = new Map([
+  private overlaysArcgis = new Map([
     ["Gemarkungen", "Gemarkungen"],
-    ["Flurstücke", "Flurstücke,Flst.Nr."],
     ["Baublöcke", "Baublöcke"],
     ["Kitaplanungsbereiche", "Kitaplanungsbereiche"],
     ["Stadtbezirke", "Stadtbezirke"],
@@ -180,6 +179,8 @@ export default class CityMap extends Vue {
     ["Grundschulsprengel", "Grundschulsprengel"],
     ["Umgriffe Bebauungspläne", "BB-Umgriff"],
   ]);
+
+  private overlaysGeo = new Map([["Flurstücke", "Flurstücke,Flst.Nr."]]);
 
   created(): void {
     /* Da die Karte ihren Zoom selber ändern kann, soll dieser Wert nur einmalig gesetzt werden.
@@ -227,8 +228,17 @@ export default class CityMap extends Vue {
   private onLayerControlReady(): void {
     const layerControl = (this.$refs.layerControl as LControlLayers).mapObject;
 
-    for (const overlay of this.overlays) {
-      const layer = (L as any).nonTiledLayer.wms(this.getGeoUrl("basis"), {
+    for (const overlay of this.overlaysGeo) {
+      const layer = (L as any).nonTiledLayer.wms(this.getGeoUrl("WMS_Stadtgrundkarte"), {
+        layers: overlay[1],
+        transparent: true,
+        ...this.LAYER_OPTIONS,
+      });
+      layerControl.addOverlay(layer, overlay[0]);
+    }
+
+    for (const overlay of this.overlaysArcgis) {
+      const layer = (L as any).nonTiledLayer.wms(this.getArcgisUrl("basis"), {
         layers: overlay[1],
         transparent: true,
         ...this.LAYER_OPTIONS,
@@ -242,6 +252,10 @@ export default class CityMap extends Vue {
    */
   private getGeoUrl(service: string): string {
     return (import.meta.env.VITE_GIS_URL as string).replace("{1}", service);
+  }
+
+  private getArcgisUrl(service: string): string {
+    return (import.meta.env.VITE_ARCGIS_URL as string).replace("{1}", service);
   }
 
   /**

--- a/frontend/src/components/map/CityMap.vue
+++ b/frontend/src/components/map/CityMap.vue
@@ -18,7 +18,7 @@
       <l-control-layers
         id="city-map-layer-control"
         ref="layerControl"
-        @ready="onLayerControlReady"
+        @ready="getTestLayer"
       />
       <!-- Die Base-Layer der Karte. Es kann nur einer zur selben Zeit sichtbar sein, da der Base-Layer der Hintergrund der Karte ist. -->
       <l-wms-tile-layer
@@ -172,6 +172,13 @@ export default class CityMap extends Vue {
   private overlays = new Map([
     ["Gemarkungen", "Gemarkungen"],
     ["Flurstücke", "Flurstücke,Flst.Nr."],
+    ["Baublöcke", "Baublöcke"],
+    ["Kitaplanungsbereiche", "Kitaplanungsbereiche"],
+    ["Stadtbezirke", "Stadtbezirke"],
+    ["Bezirksteile", "Bezirksteile"],
+    ["Stadtviertel", "Stadtviertel"],
+    ["Grundschulsprengel", "Grundschulsprengel"],
+    ["Umgriffe Bebauungspläne", "BB-Umgriff"],
   ]);
 
   created(): void {
@@ -230,11 +237,28 @@ export default class CityMap extends Vue {
     }
   }
 
+  private getTestLayer(): void {
+    const layerControl = (this.$refs.layerControl as LControlLayers).mapObject;
+
+    for (const overlay of this.overlays) {
+      const layer = (L as any).nonTiledLayer.wms(this.getArcgisUrl("basis_feature"), {
+        layers: overlay[1],
+        transparent: true,
+        ...this.LAYER_OPTIONS,
+      });
+      layerControl.addOverlay(layer, overlay[0]);
+    }
+  }
+
   /**
    * Da der Geo-Dienst mehrere Services anbietet, wird mit dieser Funktion der notwendige Service ausgewählt (ohne die URL kopieren zu müssen).
    */
   private getGeoUrl(service: string): string {
     return (import.meta.env.VITE_GIS_URL as string).replace("{1}", service);
+  }
+
+  private getArcgisUrl(service: string): string {
+    return (import.meta.env.VITE_TEST_URL as string).replace("{1}", service);
   }
 
   /**

--- a/frontend/src/components/map/CityMap.vue
+++ b/frontend/src/components/map/CityMap.vue
@@ -180,7 +180,7 @@ export default class CityMap extends Vue {
     ["Umgriffe Bebauungspläne", "BB-Umgriff"],
   ]);
 
-  private overlaysGeo = new Map([["Flurstücke", "Flurstücke,Flst.Nr."]]);
+  private overlaysGrundkarte = new Map([["Flurstücke", "Flurstücke,Flst.Nr."]]);
 
   created(): void {
     /* Da die Karte ihren Zoom selber ändern kann, soll dieser Wert nur einmalig gesetzt werden.
@@ -228,8 +228,8 @@ export default class CityMap extends Vue {
   private onLayerControlReady(): void {
     const layerControl = (this.$refs.layerControl as LControlLayers).mapObject;
 
-    for (const overlay of this.overlaysGeo) {
-      const layer = (L as any).nonTiledLayer.wms(this.getGeoUrl("WMS_Stadtgrundkarte"), {
+    for (const overlay of this.overlaysGrundkarte) {
+      const layer = (L as any).nonTiledLayer.wms(this.getArcgisUrl("Grundkarten"), {
         layers: overlay[1],
         transparent: true,
         ...this.LAYER_OPTIONS,
@@ -245,13 +245,6 @@ export default class CityMap extends Vue {
       });
       layerControl.addOverlay(layer, overlay[0]);
     }
-  }
-
-  /**
-   * Da der Geo-Dienst mehrere Services anbietet, wird mit dieser Funktion der notwendige Service ausgewählt (ohne die URL kopieren zu müssen).
-   */
-  private getGeoUrl(service: string): string {
-    return (import.meta.env.VITE_GIS_URL as string).replace("{1}", service);
   }
 
   private getArcgisUrl(service: string): string {

--- a/frontend/src/components/map/CityMap.vue
+++ b/frontend/src/components/map/CityMap.vue
@@ -172,7 +172,7 @@ export default class CityMap extends Vue {
   private overlays = new Map([
     ["Gemarkungen", "Gemarkungen"],
     ["Flurstücke", "Flurstücke,Flst.Nr."],
-    ["Baublöcke", "VABLOCK.BAUBLOCK"],
+    ["Baublöcke", "Baublöcke"],
     ["Kitaplanungsbereiche", "Kitaplanungsbereiche"],
     ["Stadtbezirke", "Stadtbezirke"],
     ["Bezirksteile", "Bezirksteile"],

--- a/frontend/src/components/map/CityMap.vue
+++ b/frontend/src/components/map/CityMap.vue
@@ -18,7 +18,7 @@
       <l-control-layers
         id="city-map-layer-control"
         ref="layerControl"
-        @ready="getTestLayer"
+        @ready="onLayerControlReady"
       />
       <!-- Die Base-Layer der Karte. Es kann nur einer zur selben Zeit sichtbar sein, da der Base-Layer der Hintergrund der Karte ist. -->
       <l-wms-tile-layer
@@ -172,7 +172,7 @@ export default class CityMap extends Vue {
   private overlays = new Map([
     ["Gemarkungen", "Gemarkungen"],
     ["Flurstücke", "Flurstücke,Flst.Nr."],
-    ["Baublöcke", "Baublöcke"],
+    ["Baublöcke", "VABLOCK.BAUBLOCK"],
     ["Kitaplanungsbereiche", "Kitaplanungsbereiche"],
     ["Stadtbezirke", "Stadtbezirke"],
     ["Bezirksteile", "Bezirksteile"],
@@ -228,20 +228,7 @@ export default class CityMap extends Vue {
     const layerControl = (this.$refs.layerControl as LControlLayers).mapObject;
 
     for (const overlay of this.overlays) {
-      const layer = (L as any).nonTiledLayer.wms(this.getGeoUrl("WMS_Stadtgrundkarte"), {
-        layers: overlay[1],
-        transparent: true,
-        ...this.LAYER_OPTIONS,
-      });
-      layerControl.addOverlay(layer, overlay[0]);
-    }
-  }
-
-  private getTestLayer(): void {
-    const layerControl = (this.$refs.layerControl as LControlLayers).mapObject;
-
-    for (const overlay of this.overlays) {
-      const layer = (L as any).nonTiledLayer.wms(this.getArcgisUrl("basis_feature"), {
+      const layer = (L as any).nonTiledLayer.wms(this.getGeoUrl("basis"), {
         layers: overlay[1],
         transparent: true,
         ...this.LAYER_OPTIONS,
@@ -255,10 +242,6 @@ export default class CityMap extends Vue {
    */
   private getGeoUrl(service: string): string {
     return (import.meta.env.VITE_GIS_URL as string).replace("{1}", service);
-  }
-
-  private getArcgisUrl(service: string): string {
-    return (import.meta.env.VITE_TEST_URL as string).replace("{1}", service);
   }
 
   /**


### PR DESCRIPTION
**Description**

Wechsel von der geoinfo zu Arcgis Basis und Grundkarten Service. 

Basis Service beinhaltet: Gemarkungen, Baublöcke, Kitaplanungsbereiche, Stadtbezirke, Bezirksstelle, Stadtviertel, Grundschulsprengel und Umgriffe Bebauungsplan

Grundkarten Service beinhaltet: Flurstück und Flurstück Nummer

**Reference**

Issues #646
