### PR TITLE
ISI-986 Anzeigen der Dateigröße zur Basis 2

### DIFF
--- a/frontend/src/components/common/dokumente/DokumenteListe.vue
+++ b/frontend/src/components/common/dokumente/DokumenteListe.vue
@@ -153,12 +153,12 @@ export default class DokumenteListe extends Mixins(DokumenteApiRequestMixin, Fie
 
   private getDokumentSizeInSIUnits(dokument: DokumentDto): string {
     let size: string;
-    if (dokument.sizeInBytes < 1000) {
+    if (dokument.sizeInBytes < 1024) {
       size = dokument.sizeInBytes + " Byte";
-    } else if (dokument.sizeInBytes < 1000000) {
-      size = _.round(dokument.sizeInBytes / 1000, 1) + " Kilobyte";
+    } else if (dokument.sizeInBytes < 1048576) {
+      size = _.round(dokument.sizeInBytes / 1024, 1) + " KB";
     } else {
-      size = _.round(dokument.sizeInBytes / 1000000, 1) + " Megabyte";
+      size = _.round(dokument.sizeInBytes / 1048576, 1) + " MB";
     }
     return size;
   }


### PR DESCRIPTION
**Description**

Bisher wurden die Dateigrößen zur Basis 10 mit Dezimalpräfix angezeigt. 

Die Anzeige wurde zur Basis 2 angepasst. Zur Vermeidung der Verwendung der Bezeichung Mebibyte und Kebibyte wird auf MB und KB gekürzt. 

**Reference**

ISI-986
