### PR TITLE
ISI-897-Entfernen-von-TS-Konsolen-Fehlern

### DIFF
--- a/frontend/src/components/abfragen/AbfrageNavigationTree.vue
+++ b/frontend/src/components/abfragen/AbfrageNavigationTree.vue
@@ -141,7 +141,7 @@ interface Action {
 interface Props {
   abfrage: BauleitplanverfahrenDto;
   selectedItemId: string;
-  relevanteAbfragevarianteId: string | null;
+  relevanteAbfragevarianteId?: null | string;
 }
 
 interface Emits {

--- a/frontend/src/components/abfragen/StatusleisteComponent.vue
+++ b/frontend/src/components/abfragen/StatusleisteComponent.vue
@@ -16,7 +16,7 @@
         <template v-for="(statusLabel, index) in statusLabels.slice(1)">
           <v-divider :key="index"></v-divider>
           <v-stepper-step
-            :key="index"
+            :key="`${index}-${statusLabel}`"
             :complete="getStatusIndex() > index"
             step=""
           >
@@ -47,7 +47,7 @@
         <template v-for="(shortenedStatusLabel, index) in shortenedStatusLabels.slice(1)">
           <v-divider :key="index"></v-divider>
           <v-stepper-step
-            :key="index"
+            :key="`${index}-${shortenedStatusLabel}`"
             :complete="getShortenedStatusIndex() > index"
             step=""
           >


### PR DESCRIPTION
**Description**

Entfernen von den Duplicate Keys indem ich der id den index und ihren Status als key setzte. 

Außerdem den AbfragenavigationTree Warning auch entfernt. Dort wurde gemekert das er einen String erwartet und null bekommt obwohl es ein Dual Type von `string | null` ist.

Nach ein bisschen recherche habe ich herausgefunden das man angeben soll bei den Props ob die property auch einen null wert haben darf wenn man am ende der Variable ein ` ?` hinzufügt.

https://stackoverflow.com/a/17220359

**Reference**

Issues #987
