### PR TITLE
ISI-742 ISI-1431 Sichtbarkeit der Links zu Reports

### DIFF
--- a/frontend/src/components/abfragevarianten/SachbearbeitungComponent.vue
+++ b/frontend/src/components/abfragevarianten/SachbearbeitungComponent.vue
@@ -196,6 +196,7 @@ export default class AbfragevarianteSachbearbeitungFormular extends Mixins(
   private showSobonReport(): boolean {
     const abfrage = this.searchStore.selectedAbfrage;
     return (
+      !this.hasOnlyRoleAnwender() &&
       this.isBauleitplanverfahrenOrWeiteresVerfahren &&
       !_.isNil(this.abfragevarianteSachbearbeitung.sobonBerechnung) &&
       abfrage.sobonRelevant === UncertainBoolean.True &&

--- a/frontend/src/components/abfragevarianten/SachbearbeitungComponent.vue
+++ b/frontend/src/components/abfragevarianten/SachbearbeitungComponent.vue
@@ -65,14 +65,17 @@
           cols="12"
           md="6"
         >
-          <reports-planungsursaechlichkeit-component v-model="abfragevarianteSachbearbeitung" />
+          <reports-planungsursaechlichkeit-component
+            v-if="showPlanungsursaechlichenReport()"
+            v-model="abfragevarianteSachbearbeitung"
+          />
         </v-col>
         <v-col
           cols="12"
           md="6"
         >
           <reports-sobonursaechlichkeit-component
-            v-if="showSobonReport()"
+            v-if="showSobonReports()"
             v-model="abfragevarianteSachbearbeitung"
           />
         </v-col>
@@ -191,9 +194,16 @@ export default class AbfragevarianteSachbearbeitungFormular extends Mixins(
   }
 
   /**
-   * Überprüfung ob alle Kriterien stimmen um die Sobon Report anzuzeigen.
+   * Überprüfung ob alle Kriterien stimmen um die planungsursächlichen Reports anzuzeigen.
    */
-  private showSobonReport(): boolean {
+  private showPlanungsursaechlichenReport(): boolean {
+    return this.isRoleAdminOrSachbearbeitung() || this.isRoleAdminOrBedarfsmeldung();
+  }
+
+  /**
+   * Überprüfung ob alle Kriterien stimmen um die Sobon Reports anzuzeigen.
+   */
+  private showSobonReports(): boolean {
     const abfrage = this.searchStore.selectedAbfrage;
     return (
       !this.hasOnlyRoleAnwender() &&

--- a/frontend/src/components/abfragevarianten/SachbearbeitungComponent.vue
+++ b/frontend/src/components/abfragevarianten/SachbearbeitungComponent.vue
@@ -66,7 +66,7 @@
           md="6"
         >
           <reports-planungsursaechlichkeit-component
-            v-if="showPlanungsursaechlichenReports()"
+            v-if="showPlanungsursaechlicheReports()"
             v-model="abfragevarianteSachbearbeitung"
           />
         </v-col>
@@ -196,7 +196,7 @@ export default class AbfragevarianteSachbearbeitungFormular extends Mixins(
   /**
    * Überprüfung ob alle Kriterien stimmen um die planungsursächlichen Reports anzuzeigen.
    */
-  public showPlanungsursaechlichenReports(): boolean {
+  public showPlanungsursaechlicheReports(): boolean {
     return this.isRoleAdminOrSachbearbeitung() || this.isRoleAdminOrBedarfsmeldung();
   }
 

--- a/frontend/src/components/abfragevarianten/SachbearbeitungComponent.vue
+++ b/frontend/src/components/abfragevarianten/SachbearbeitungComponent.vue
@@ -66,7 +66,7 @@
           md="6"
         >
           <reports-planungsursaechlichkeit-component
-            v-if="showPlanungsursaechlichenReport()"
+            v-if="showPlanungsursaechlichenReports()"
             v-model="abfragevarianteSachbearbeitung"
           />
         </v-col>
@@ -196,14 +196,14 @@ export default class AbfragevarianteSachbearbeitungFormular extends Mixins(
   /**
    * Überprüfung ob alle Kriterien stimmen um die planungsursächlichen Reports anzuzeigen.
    */
-  private showPlanungsursaechlichenReport(): boolean {
+  public showPlanungsursaechlichenReports(): boolean {
     return this.isRoleAdminOrSachbearbeitung() || this.isRoleAdminOrBedarfsmeldung();
   }
 
   /**
    * Überprüfung ob alle Kriterien stimmen um die Sobon Reports anzuzeigen.
    */
-  private showSobonReports(): boolean {
+  public showSobonReports(): boolean {
     const abfrage = this.searchStore.selectedAbfrage;
     return (
       !this.hasOnlyRoleAnwender() &&
@@ -219,7 +219,7 @@ export default class AbfragevarianteSachbearbeitungFormular extends Mixins(
     );
   }
 
-  private get isBauleitplanverfahrenOrWeiteresVerfahren(): boolean {
+  get isBauleitplanverfahrenOrWeiteresVerfahren(): boolean {
     return (
       !_.isNil(this.abfragevarianteSachbearbeitung) &&
       (this.abfragevarianteSachbearbeitung?.artAbfragevariante ===


### PR DESCRIPTION
**Description**

* Die Links zu den planungsursächlichen Reports sind nur für die Rollen Sachbearbeitung und Bedarfsmeldung ersichtlich.
* Die Links zu den Sobon-ursächlichen Reports sind nur für die Rolle das Anwenders nicht sichtbar. Für alle anderen Rollen sind die Links ersichtlich

**Reference**

ISI-742 ISI-1431
