### PR TITLE
ISI-1829-Geodaten-EAI-bei-Erstaufruf-nicht-verfuegbar

### DIFF
--- a/frontend/src/composables/requests/eai/GeodataEaiApi.ts
+++ b/frontend/src/composables/requests/eai/GeodataEaiApi.ts
@@ -45,11 +45,16 @@ export function useGeodataEaiApi() {
 
   async function getFlurstueckeForPoint(point: PointGeometryDto): Promise<Array<FeatureDtoFlurstueckDto>> {
     const request: GetFlurstuecke1Request = { pointGeometryDto: point };
-    try {
-      const response = await punktApi.getFlurstuecke1(request, RequestUtils.getPOSTConfig());
-      return response.features ?? [];
-    } catch (error) {
-      throw handleErrorInternal(error);
+    const maxIterations = 3; // Prävention für den Fall, dass noch keine Session zu Geodata-EAI aufgebaut ist
+    for (let i = 0; i < maxIterations; i++) {
+      try {
+        const response = await punktApi.getFlurstuecke1(request, RequestUtils.getPOSTConfig());
+        return response.features ?? [];
+      } catch (error) {
+        if (i === maxIterations - 1) {
+          throw handleErrorInternal(error);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
**Description**

Beim Erstaufruf der Geodata-EAI wird im Falle, dass noch keine Server Session existiert, ein Fehler geworfen. Es werden nun 3 Zugriffsversuche unternommen, bevor ein Fehler geworfen wird. Dies soll eine ggf. fehlende Server Session aufbauen.

**Reference**

Issues #ISI-1829
