### PR TITLE
ISI-1804-Datenuebernahme-mit-Abfragevariante-2.x-wird-nicht-gespeichert

### DIFF
--- a/src/utils/MapperUtil.ts
+++ b/src/utils/MapperUtil.ts
@@ -720,17 +720,18 @@ export function groupItemsToHeader(foerdermixStaemme: FoerdermixStammModel[], so
  */
 export function copyAbfrageOrAbfragevariante<T extends AnyAbfrageDto | AnyAbfragevarianteDto>(value: T): T {
   const copy = _.cloneDeep(value);
-  if (!_.isNil(value as AnyAbfrageDto)) {
-    sanitzeAbfragevarianteSachbearbeitung(copy);
+  if ("statusAbfrage" in value && "artAbfrage" in value) {
+    sanitzeAbfragevariantenSachbearbeitung(copy);
   }
   sanitizeCopy(copy);
   copy.name = (copy.name ?? "") + " - Kopie";
   return copy;
 }
 /*
- * Wenn die Sachbearbeitung eine Abfrage durch "Datenübernahme" kopiert, sollen nur die Abfragevarianten der Abfrageerstellung (Nr. 1.x) übernommen werden
+ * Wenn die Sachbearbeitung eine Abfrage durch "Datenübernahme" kopiert, sollen nur die Abfragevarianten der Abfrageerstellung (Abfragevariante Nr. 1.x) übernommen werden,
+ * nicht aber die der Sachbearbeitung (Abfragevariante Nr. 2.x)
  */
-function sanitzeAbfragevarianteSachbearbeitung<T extends AnyAbfrageDto>(value: T): T {
+function sanitzeAbfragevariantenSachbearbeitung<T extends AnyAbfrageDto>(value: T): T {
   if (value.statusAbfrage === StatusAbfrage.StartBearbeitung) {
     if (value.artAbfrage === AbfrageDtoArtAbfrageEnum.Bauleitplanverfahren) {
       (value as BauleitplanverfahrenDto).abfragevariantenSachbearbeitungBauleitplanverfahren = [];

--- a/src/utils/MapperUtil.ts
+++ b/src/utils/MapperUtil.ts
@@ -42,7 +42,6 @@ import FoerdermixModel from "@/types/model/bauraten/FoerdermixModel";
 import _ from "lodash";
 import { createSobonBerechnungBauleitplanverfahren } from "./Factories";
 import { AnyAbfrageDto, AnyAbfragevarianteDto } from "@/types/common/Abfrage";
-import { useSecurity } from "@/composables/security/Security";
 
 type GroupedStammdaten = Array<{ header: string } | FoerdermixStammModel>;
 

--- a/src/utils/MapperUtil.ts
+++ b/src/utils/MapperUtil.ts
@@ -721,7 +721,7 @@ export function groupItemsToHeader(foerdermixStaemme: FoerdermixStammModel[], so
 export function copyAbfrageOrAbfragevariante<T extends AnyAbfrageDto | AnyAbfragevarianteDto>(value: T): T {
   const copy = _.cloneDeep(value);
   if ("statusAbfrage" in value && "artAbfrage" in value) {
-    sanitzeAbfragevariantenSachbearbeitung(copy);
+    sanitizeAbfragevariantenSachbearbeitung(copy);
   }
   sanitizeCopy(copy);
   copy.name = (copy.name ?? "") + " - Kopie";
@@ -731,7 +731,7 @@ export function copyAbfrageOrAbfragevariante<T extends AnyAbfrageDto | AnyAbfrag
  * Wenn die Sachbearbeitung eine Abfrage durch "Datenübernahme" kopiert, sollen nur die Abfragevarianten der Abfrageerstellung (Abfragevariante Nr. 1.x) übernommen werden,
  * nicht aber die der Sachbearbeitung (Abfragevariante Nr. 2.x)
  */
-function sanitzeAbfragevariantenSachbearbeitung<T extends AnyAbfrageDto>(value: T): T {
+function sanitizeAbfragevariantenSachbearbeitung<T extends AnyAbfrageDto>(value: T): T {
   if (value.statusAbfrage === StatusAbfrage.StartBearbeitung) {
     if (value.artAbfrage === AbfrageDtoArtAbfrageEnum.Bauleitplanverfahren) {
       (value as BauleitplanverfahrenDto).abfragevariantenSachbearbeitungBauleitplanverfahren = [];

--- a/src/utils/MapperUtil.ts
+++ b/src/utils/MapperUtil.ts
@@ -1,4 +1,4 @@
-import type {
+import {
   BauleitplanverfahrenDto,
   BaugenehmigungsverfahrenDto,
   WeiteresVerfahrenDto,
@@ -29,6 +29,7 @@ import type {
   AbfragevarianteBauleitplanverfahrenEinplanungBedarfeDto,
   AbfragevarianteBaugenehmigungsverfahrenEinplanungBedarfeDto,
   AbfragevarianteWeiteresVerfahrenEinplanungBedarfeDto,
+  AbfrageDtoArtAbfrageEnum,
 } from "@/api/api-client/isi-backend";
 import {
   AbfragevarianteBauleitplanverfahrenAngelegtDtoArtAbfragevarianteEnum,
@@ -41,6 +42,7 @@ import FoerdermixModel from "@/types/model/bauraten/FoerdermixModel";
 import _ from "lodash";
 import { createSobonBerechnungBauleitplanverfahren } from "./Factories";
 import { AnyAbfrageDto, AnyAbfragevarianteDto } from "@/types/common/Abfrage";
+import { useSecurity } from "@/composables/security/Security";
 
 type GroupedStammdaten = Array<{ header: string } | FoerdermixStammModel>;
 
@@ -718,9 +720,27 @@ export function groupItemsToHeader(foerdermixStaemme: FoerdermixStammModel[], so
  */
 export function copyAbfrageOrAbfragevariante<T extends AnyAbfrageDto | AnyAbfragevarianteDto>(value: T): T {
   const copy = _.cloneDeep(value);
+  if (!_.isNil(value as AnyAbfrageDto)) {
+    sanitzeAbfragevarianteSachbearbeitung(copy);
+  }
   sanitizeCopy(copy);
   copy.name = (copy.name ?? "") + " - Kopie";
   return copy;
+}
+/*
+ * Wenn die Sachbearbeitung eine Abfrage durch "Datenübernahme" kopiert, sollen nur die Abfragevarianten der Abfrageerstellung (Nr. 1.x) übernommen werden
+ */
+function sanitzeAbfragevarianteSachbearbeitung<T extends AnyAbfrageDto>(value: T): T {
+  if (value.statusAbfrage === StatusAbfrage.StartBearbeitung) {
+    if (value.artAbfrage === AbfrageDtoArtAbfrageEnum.Bauleitplanverfahren) {
+      (value as BauleitplanverfahrenDto).abfragevariantenSachbearbeitungBauleitplanverfahren = [];
+    } else if (value.artAbfrage === AbfrageDtoArtAbfrageEnum.Baugenehmigungsverfahren) {
+      (value as BaugenehmigungsverfahrenDto).abfragevariantenSachbearbeitungBaugenehmigungsverfahren = [];
+    } else if (value.artAbfrage === AbfrageDtoArtAbfrageEnum.WeiteresVerfahren) {
+      (value as WeiteresVerfahrenDto).abfragevariantenSachbearbeitungWeiteresVerfahren = [];
+    }
+  }
+  return value;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
**Description**

Bugfix: https://jira.muenchen.de/browse/ISI-1804

**Reference**

Issues #ISI-1804


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Copy operations now strip processing-specific handling variants for certain procedure types when the source is in the initial handling state, preventing unwanted processing variants from being duplicated and ensuring only creation variants are preserved during copy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->