### PR TITLE
ISI2-120-Anpassung-der-Bauraten-bei-nachträglicher-Veränderung-Attribut-Realisierung-von

### DIFF
--- a/src/components/abfragen/AbfrageNavigationTree.vue
+++ b/src/components/abfragen/AbfrageNavigationTree.vue
@@ -502,14 +502,28 @@ function bauratenDeterminableForAbfragevariante(abfragevariante: AnyAbfragevaria
     // Entweder müssen die Geschoßläche Wohnen oder die Wohneinheiten gesetzt sein.
     (!_.isNil(abfragevariante.weGesamt) || !_.isNil(abfragevariante.gfWohnenGesamt)) &&
     // Die Abfragevariante darf keine Bauabschnitte referenzieren.
-    (_.isEmpty(abfragevariante.bauabschnitte) || isTechnicalBauabschnitt(abfragevariante.bauabschnitte)) &&
+    (_.isEmpty(abfragevariante.bauabschnitte) || isTechnicalOhneBauraten(abfragevariante.bauabschnitte)) &&
     // Das Datum für Realisierung von muss gesetzt sein.
     !_.isNil(abfragevariante.realisierungVon)
   );
 }
 
-function isTechnicalBauabschnitt(bauabschnitte?: BauabschnittDto[]): boolean {
-  return !_.isEmpty(bauabschnitte) && bauabschnitte?.length == 1 && bauabschnitte[0].technical;
+function isTechnicalOhneBauraten(bauabschnitte?: BauabschnittDto[]): boolean {
+  let isTechnicalOhneBauraten = true;
+  if (!_.isEmpty(bauabschnitte)) {
+    bauabschnitte?.forEach((bauabschnitt) => {
+      if (bauabschnitt.technical) {
+        bauabschnitt.baugebiete.forEach((baugebiet) => {
+          if (!baugebiet.technical || !_.isEmpty(baugebiet.bauraten)) {
+            isTechnicalOhneBauraten = false;
+          }
+        });
+      } else {
+        isTechnicalOhneBauraten = false;
+      }
+    });
+    return isTechnicalOhneBauraten;
+  }
 }
 
 function bauratenDeterminableForBaugebiet(baugebiet: BaugebietDto): boolean {

--- a/src/components/abfragen/AbfrageNavigationTree.vue
+++ b/src/components/abfragen/AbfrageNavigationTree.vue
@@ -502,10 +502,14 @@ function bauratenDeterminableForAbfragevariante(abfragevariante: AnyAbfragevaria
     // Entweder müssen die Geschoßläche Wohnen oder die Wohneinheiten gesetzt sein.
     (!_.isNil(abfragevariante.weGesamt) || !_.isNil(abfragevariante.gfWohnenGesamt)) &&
     // Die Abfragevariante darf keine Bauabschnitte referenzieren.
-    _.isEmpty(abfragevariante.bauabschnitte) &&
+    (_.isEmpty(abfragevariante.bauabschnitte) || isTechnicalBauabschnitt(abfragevariante.bauabschnitte)) &&
     // Das Datum für Realisierung von muss gesetzt sein.
     !_.isNil(abfragevariante.realisierungVon)
   );
+}
+
+function isTechnicalBauabschnitt(bauabschnitte?: BauabschnittDto[]): boolean {
+  return !_.isEmpty(bauabschnitte) && bauabschnitte?.length == 1 && bauabschnitte[0].technical;
 }
 
 function bauratenDeterminableForBaugebiet(baugebiet: BaugebietDto): boolean {

--- a/src/components/abfragen/AbfrageNavigationTree.vue
+++ b/src/components/abfragen/AbfrageNavigationTree.vue
@@ -522,8 +522,8 @@ function isTechnicalOhneBauraten(bauabschnitte?: BauabschnittDto[]): boolean {
         isTechnicalOhneBauraten = false;
       }
     });
-    return isTechnicalOhneBauraten;
   }
+  return isTechnicalOhneBauraten;
 }
 
 function bauratenDeterminableForBaugebiet(baugebiet: BaugebietDto): boolean {

--- a/src/components/abfragevarianten/baugenehmigungsverfahren/CommonBaugenehmigungsverfahrenComponent.vue
+++ b/src/components/abfragevarianten/baugenehmigungsverfahren/CommonBaugenehmigungsverfahrenComponent.vue
@@ -198,7 +198,15 @@ function wesentlicheRechtsgrundlageChanged(): void {
 }
 
 function realisierungVonChanged(): void {
-  isDialogBauratenLoeschenOpen.value = true;
+  isDialogBauratenLoeschenOpen.value = existsBauraten();
+}
+
+function existsBauraten(): boolean {
+  return (
+    abfragevariante.value.bauabschnitte?.some((bauabschnitt) =>
+      bauabschnitt.baugebiete?.some((baugebiet) => !_.isEmpty(baugebiet.bauraten)),
+    ) ?? false
+  );
 }
 
 function deleteBauraten(): void {

--- a/src/components/abfragevarianten/baugenehmigungsverfahren/CommonBaugenehmigungsverfahrenComponent.vue
+++ b/src/components/abfragevarianten/baugenehmigungsverfahren/CommonBaugenehmigungsverfahrenComponent.vue
@@ -95,6 +95,7 @@
             year
             maxlength="4"
             required
+            @focus="saveRealisierungVon"
             @blur="realisierungVonChanged"
             help="Erfolgt bei Datum 'Realisierung von' eine Eingabe, werden alle Bauraten gelöscht."
             :class="isEditable ? '' : 'text-grey-lighten-1'"
@@ -159,6 +160,8 @@ const lookupStore = useLookupStore();
 
 const { formChanged } = useSaveLeave();
 
+const originalRealisierungVon = ref<number | null>();
+
 const wesentlicheRechtsgrundlageBaugenehmigungsverfahrenList = computed(
   () => lookupStore.wesentlicheRechtsgrundlageBaugenehmigungsverfahren,
 );
@@ -198,8 +201,14 @@ function wesentlicheRechtsgrundlageChanged(): void {
   }
 }
 
+function saveRealisierungVon(): void {
+  originalRealisierungVon.value = abfragevariante.value.realisierungVon;
+}
+
 function realisierungVonChanged(): void {
-  isDialogBauratenLoeschenOpen.value = existsBauraten(abfragevariante.value.bauabschnitte);
+  isDialogBauratenLoeschenOpen.value =
+    originalRealisierungVon.value != abfragevariante.value.realisierungVon &&
+    existsBauraten(abfragevariante.value.bauabschnitte);
 }
 
 function yesNoDialogBauratenLoeschenYes(): void {

--- a/src/components/abfragevarianten/baugenehmigungsverfahren/CommonBaugenehmigungsverfahrenComponent.vue
+++ b/src/components/abfragevarianten/baugenehmigungsverfahren/CommonBaugenehmigungsverfahrenComponent.vue
@@ -96,7 +96,7 @@
             maxlength="4"
             required
             @blur="realisierungVonChanged"
-            help="Erfolgt bei Datum Realisierung von eine Eingabe, werden alle Bauraten gelöscht."
+            help="Erfolgt bei Datum 'Realisierung von' eine Eingabe, werden alle Bauraten gelöscht."
             :class="isEditable ? '' : 'text-grey-lighten-1'"
           />
         </v-col>

--- a/src/components/abfragevarianten/baugenehmigungsverfahren/CommonBaugenehmigungsverfahrenComponent.vue
+++ b/src/components/abfragevarianten/baugenehmigungsverfahren/CommonBaugenehmigungsverfahrenComponent.vue
@@ -95,6 +95,8 @@
             year
             maxlength="4"
             required
+            @blur="realisierungVonChanged"
+            help="Erfolgt bei Datum Realisierung von eine Eingabe, werden alle Bauraten gelöscht."
             :class="isEditable ? '' : 'text-grey-lighten-1'"
           />
         </v-col>
@@ -115,6 +117,17 @@
       </v-row>
     </field-group-card>
   </v-container>
+  <yes-no-dialog
+    id="bauraten_loeschen_yes_no_dialog"
+    v-model="isDialogBauratenLoeschenOpen"
+    icon="mdi-delete-forever"
+    dialogtitle="Hinweis"
+    dialogtext="Hiermit werden alle Bauraten unwiderruflich gelöscht."
+    no-text="Abbrechen"
+    yes-text="Ändern"
+    @no="yesNoDialogBauratenLoeschenNo"
+    @yes="yesNoDialogBauratenLoeschenYes"
+  />
 </template>
 
 <script setup lang="ts">
@@ -127,6 +140,7 @@ import AbfragevarianteBaugenehmigungsverfahrenModel from "@/types/model/abfragev
 import _ from "lodash";
 import { pflichtfeld, pflichtfeldMehrfachauswahl, notUnspecified } from "@/utils/FieldValidationRules";
 import { useSaveLeave } from "@/composables/SaveLeave";
+import YesNoDialog from "@/components/common/YesNoDialog.vue";
 
 interface Props {
   isEditable?: boolean;
@@ -137,6 +151,8 @@ const abfragevariante = defineModel<AbfragevarianteBaugenehmigungsverfahrenModel
 const wesentlicheRechtsgrundlageFreieEingabeVisible = ref<boolean | null>();
 
 const wesentlicheRechtsgrundlageAngabenZurBefreiungVisible = ref<boolean | null>();
+
+const isDialogBauratenLoeschenOpen = ref(false);
 
 const lookupStore = useLookupStore();
 
@@ -179,5 +195,26 @@ function wesentlicheRechtsgrundlageChanged(): void {
     abfragevariante.value.wesentlicheRechtsgrundlageAngabenZurBefreiung = undefined;
     wesentlicheRechtsgrundlageAngabenZurBefreiungVisible.value = false;
   }
+}
+
+function realisierungVonChanged(): void {
+  isDialogBauratenLoeschenOpen.value = true;
+}
+
+function deleteBauraten(): void {
+  abfragevariante.value.bauabschnitte?.forEach((bauabschnitt) => {
+    bauabschnitt.baugebiete.forEach((baugebiet) => {
+      baugebiet.bauraten = [];
+    });
+  });
+}
+
+function yesNoDialogBauratenLoeschenYes(): void {
+  deleteBauraten();
+  yesNoDialogBauratenLoeschenNo();
+}
+
+function yesNoDialogBauratenLoeschenNo(): void {
+  isDialogBauratenLoeschenOpen.value = false;
 }
 </script>

--- a/src/components/abfragevarianten/baugenehmigungsverfahren/CommonBaugenehmigungsverfahrenComponent.vue
+++ b/src/components/abfragevarianten/baugenehmigungsverfahren/CommonBaugenehmigungsverfahrenComponent.vue
@@ -96,7 +96,7 @@
             maxlength="4"
             required
             @blur="realisierungVonChanged"
-            help="Erfolgt bei Datum Realisierung von eine Eingabe, werden alle Bauraten gelöscht."
+            help="Erfolgt bei Datum 'Realisierung von' eine Eingabe, werden alle Bauraten gelöscht."
             :class="isEditable ? '' : 'text-grey-lighten-1'"
           />
         </v-col>
@@ -141,6 +141,7 @@ import _ from "lodash";
 import { pflichtfeld, pflichtfeldMehrfachauswahl, notUnspecified } from "@/utils/FieldValidationRules";
 import { useSaveLeave } from "@/composables/SaveLeave";
 import YesNoDialog from "@/components/common/YesNoDialog.vue";
+import { existsBauraten, deleteBauraten } from "@/utils/AbfragevarianteUtil";
 
 interface Props {
   isEditable?: boolean;
@@ -198,27 +199,11 @@ function wesentlicheRechtsgrundlageChanged(): void {
 }
 
 function realisierungVonChanged(): void {
-  isDialogBauratenLoeschenOpen.value = existsBauraten();
-}
-
-function existsBauraten(): boolean {
-  return (
-    abfragevariante.value.bauabschnitte?.some((bauabschnitt) =>
-      bauabschnitt.baugebiete?.some((baugebiet) => !_.isEmpty(baugebiet.bauraten)),
-    ) ?? false
-  );
-}
-
-function deleteBauraten(): void {
-  abfragevariante.value.bauabschnitte?.forEach((bauabschnitt) => {
-    bauabschnitt.baugebiete.forEach((baugebiet) => {
-      baugebiet.bauraten = [];
-    });
-  });
+  isDialogBauratenLoeschenOpen.value = existsBauraten(abfragevariante.value.bauabschnitte);
 }
 
 function yesNoDialogBauratenLoeschenYes(): void {
-  deleteBauraten();
+  deleteBauraten(abfragevariante.value.bauabschnitte);
   yesNoDialogBauratenLoeschenNo();
 }
 

--- a/src/components/abfragevarianten/bauleitplanverfahren/CommonBauleitplanverfahrenComponent.vue
+++ b/src/components/abfragevarianten/bauleitplanverfahren/CommonBauleitplanverfahrenComponent.vue
@@ -97,7 +97,7 @@
           year
           maxlength="4"
           required
-          @update:model-value="realisierungVonChanged"
+          @blur="realisierungVonChanged"
           help="Erfolgt bei Datum Satzungsbeschluss eine Eingabe, wird das Datum 'Realisierung von' neu berechnet. 'Realisierung von' kann jedoch weiterhin geändert werden. Dabei werden alle Bauraten gelöscht."
           :class="isEditable ? '' : 'text-grey-lighten-1'"
         />

--- a/src/components/abfragevarianten/bauleitplanverfahren/CommonBauleitplanverfahrenComponent.vue
+++ b/src/components/abfragevarianten/bauleitplanverfahren/CommonBauleitplanverfahrenComponent.vue
@@ -30,6 +30,7 @@
           :disabled="!isEditable"
           label="Datum Satzungsbeschluss"
           month-picker
+          @focus="saveDatumSatzungsbeschluss"
           @blur="datumSatzungsbeschlussChanged"
           help="Erfolgt bei Datum 'Satzungsbeschluss' eine Eingabe, werden alle Bauraten gelöscht."
         />
@@ -97,6 +98,7 @@
           year
           maxlength="4"
           required
+          @focus="saveRealisierungVon"
           @blur="realisierungVonChanged"
           help="Erfolgt bei Datum 'Satzungsbeschluss' eine Eingabe, wird das Datum 'Realisierung von' neu berechnet. 'Realisierung von' kann jedoch weiterhin geändert werden. Dabei werden alle Bauraten gelöscht."
           :class="isEditable ? '' : 'text-grey-lighten-1'"
@@ -161,6 +163,9 @@ const { formChanged } = useSaveLeave();
 
 const planartList = computed(() => lookupStore.planart);
 
+const originalSatzungsbeschluss = ref<Date | null>();
+const originalRealisierungVon = ref<number | null>();
+
 const calcRealisierungBis = computed(() => {
   const jahre: Array<number> | undefined = abfragevariante.value.bauabschnitte
     ?.flatMap((bauabschnitt) => bauabschnitt.baugebiete)
@@ -181,7 +186,9 @@ function datumSatzungsbeschlussChanged(): void {
         ? datumSatzungsbeschluss.getFullYear() + 3
         : datumSatzungsbeschluss.getFullYear() + 4;
   }
-  isDialogBauratenLoeschenOpen.value = existsBauraten(abfragevariante.value.bauabschnitte);
+  isDialogBauratenLoeschenOpen.value =
+    originalSatzungsbeschluss != abfragevariante.value.satzungsbeschluss &&
+    existsBauraten(abfragevariante.value.bauabschnitte);
 }
 
 withDefaults(defineProps<Props>(), { isEditable: false });
@@ -197,8 +204,18 @@ function planartChanged(): void {
   }
 }
 
+function saveDatumSatzungsbeschluss(): void {
+  originalSatzungsbeschluss.value = abfragevariante.value.satzungsbeschluss;
+}
+
+function saveRealisierungVon(): void {
+  originalRealisierungVon.value = abfragevariante.value.realisierungVon;
+}
+
 function realisierungVonChanged(): void {
-  isDialogBauratenLoeschenOpen.value = existsBauraten(abfragevariante.value.bauabschnitte);
+  isDialogBauratenLoeschenOpen.value =
+    originalRealisierungVon.value != abfragevariante.value.realisierungVon &&
+    existsBauraten(abfragevariante.value.bauabschnitte);
 }
 
 function yesNoDialogBauratenLoeschenYes(): void {

--- a/src/components/abfragevarianten/bauleitplanverfahren/CommonBauleitplanverfahrenComponent.vue
+++ b/src/components/abfragevarianten/bauleitplanverfahren/CommonBauleitplanverfahrenComponent.vue
@@ -31,6 +31,7 @@
           label="Datum Satzungsbeschluss"
           month-picker
           @blur="datumSatzungsbeschlussChanged"
+          help="Erfolgt bei Datum Satzungsbeschluss eine Eingabe, werden alle Bauraten gelöscht."
         />
       </v-col>
       <v-col
@@ -96,7 +97,8 @@
           year
           maxlength="4"
           required
-          help="Erfolgt bei Datum Satzungsbeschluss eine Eingabe, wird das Datum 'Realisierung von' neu berechnet. 'Realisierung von' kann jedoch weiterhin geändert werden."
+          @update:model-value="realisierungVonChanged"
+          help="Erfolgt bei Datum Satzungsbeschluss eine Eingabe, wird das Datum 'Realisierung von' neu berechnet. 'Realisierung von' kann jedoch weiterhin geändert werden. Dabei werden alle Bauraten gelöscht."
           :class="isEditable ? '' : 'text-grey-lighten-1'"
         />
       </v-col>
@@ -116,6 +118,17 @@
       </v-col>
     </v-row>
   </field-group-card>
+  <yes-no-dialog
+    id="bauraten_loeschen_yes_no_dialog"
+    v-model="isDialogBauratenLoeschenOpen"
+    icon="mdi-delete-forever"
+    dialogtitle="Hinweis"
+    dialogtext="Hiermit werden alle Bauraten unwiderruflich gelöscht."
+    no-text="Abbrechen"
+    yes-text="Ändern"
+    @no="yesNoDialogBauratenLoeschenNo"
+    @yes="yesNoDialogBauratenLoeschenYes"
+  />
 </template>
 
 <script setup lang="ts">
@@ -129,6 +142,7 @@ import { useLookupStore } from "@/stores/LookupStore";
 import AbfragevarianteBauleitplanverfahrenModel from "@/types/model/abfragevariante/AbfragevarianteBauleitplanverfahrenModel";
 import { notUnspecified, pflichtfeld, pflichtfeldMehrfachauswahl } from "@/utils/FieldValidationRules";
 import _ from "lodash";
+import YesNoDialog from "@/components/common/YesNoDialog.vue";
 
 interface Props {
   isEditable?: boolean;
@@ -137,6 +151,8 @@ interface Props {
 const abfragevariante = defineModel<AbfragevarianteBauleitplanverfahrenModel>({ required: true });
 
 const planartFreieEingabeVisible = ref<boolean | null>();
+
+const isDialogBauratenLoeschenOpen = ref(false);
 
 const lookupStore = useLookupStore();
 
@@ -164,6 +180,7 @@ function datumSatzungsbeschlussChanged(): void {
         ? datumSatzungsbeschluss.getFullYear() + 3
         : datumSatzungsbeschluss.getFullYear() + 4;
   }
+  isDialogBauratenLoeschenOpen.value = true;
 }
 
 withDefaults(defineProps<Props>(), { isEditable: false });
@@ -177,5 +194,26 @@ function planartChanged(): void {
     abfragevariante.value.planartFreieEingabe = undefined;
     planartFreieEingabeVisible.value = false;
   }
+}
+
+function realisierungVonChanged(): void {
+  isDialogBauratenLoeschenOpen.value = true;
+}
+
+function deleteBauraten(): void {
+  abfragevariante.value.bauabschnitte?.forEach((bauabschnitt) => {
+    bauabschnitt.baugebiete.forEach((baugebiet) => {
+      baugebiet.bauraten = [];
+    });
+  });
+}
+
+function yesNoDialogBauratenLoeschenYes(): void {
+  deleteBauraten();
+  yesNoDialogBauratenLoeschenNo();
+}
+
+function yesNoDialogBauratenLoeschenNo(): void {
+  isDialogBauratenLoeschenOpen.value = false;
 }
 </script>

--- a/src/components/abfragevarianten/bauleitplanverfahren/CommonBauleitplanverfahrenComponent.vue
+++ b/src/components/abfragevarianten/bauleitplanverfahren/CommonBauleitplanverfahrenComponent.vue
@@ -31,7 +31,7 @@
           label="Datum Satzungsbeschluss"
           month-picker
           @blur="datumSatzungsbeschlussChanged"
-          help="Erfolgt bei Datum Satzungsbeschluss eine Eingabe, werden alle Bauraten gelöscht."
+          help="Erfolgt bei Datum 'Satzungsbeschluss' eine Eingabe, werden alle Bauraten gelöscht."
         />
       </v-col>
       <v-col
@@ -98,7 +98,7 @@
           maxlength="4"
           required
           @blur="realisierungVonChanged"
-          help="Erfolgt bei Datum Satzungsbeschluss eine Eingabe, wird das Datum 'Realisierung von' neu berechnet. 'Realisierung von' kann jedoch weiterhin geändert werden. Dabei werden alle Bauraten gelöscht."
+          help="Erfolgt bei Datum 'Satzungsbeschluss' eine Eingabe, wird das Datum 'Realisierung von' neu berechnet. 'Realisierung von' kann jedoch weiterhin geändert werden. Dabei werden alle Bauraten gelöscht."
           :class="isEditable ? '' : 'text-grey-lighten-1'"
         />
       </v-col>
@@ -143,6 +143,7 @@ import AbfragevarianteBauleitplanverfahrenModel from "@/types/model/abfragevaria
 import { notUnspecified, pflichtfeld, pflichtfeldMehrfachauswahl } from "@/utils/FieldValidationRules";
 import _ from "lodash";
 import YesNoDialog from "@/components/common/YesNoDialog.vue";
+import { existsBauraten, deleteBauraten } from "@/utils/AbfragevarianteUtil";
 
 interface Props {
   isEditable?: boolean;
@@ -180,7 +181,7 @@ function datumSatzungsbeschlussChanged(): void {
         ? datumSatzungsbeschluss.getFullYear() + 3
         : datumSatzungsbeschluss.getFullYear() + 4;
   }
-  isDialogBauratenLoeschenOpen.value = existsBauraten();
+  isDialogBauratenLoeschenOpen.value = existsBauraten(abfragevariante.value.bauabschnitte);
 }
 
 withDefaults(defineProps<Props>(), { isEditable: false });
@@ -197,27 +198,11 @@ function planartChanged(): void {
 }
 
 function realisierungVonChanged(): void {
-  isDialogBauratenLoeschenOpen.value = existsBauraten();
-}
-
-function existsBauraten(): boolean {
-  return (
-    abfragevariante.value.bauabschnitte?.some((bauabschnitt) =>
-      bauabschnitt.baugebiete?.some((baugebiet) => !_.isEmpty(baugebiet.bauraten)),
-    ) ?? false
-  );
-}
-
-function deleteBauraten(): void {
-  abfragevariante.value.bauabschnitte?.forEach((bauabschnitt) => {
-    bauabschnitt.baugebiete.forEach((baugebiet) => {
-      baugebiet.bauraten = [];
-    });
-  });
+  isDialogBauratenLoeschenOpen.value = existsBauraten(abfragevariante.value.bauabschnitte);
 }
 
 function yesNoDialogBauratenLoeschenYes(): void {
-  deleteBauraten();
+  deleteBauraten(abfragevariante.value.bauabschnitte);
   yesNoDialogBauratenLoeschenNo();
 }
 

--- a/src/components/abfragevarianten/bauleitplanverfahren/CommonBauleitplanverfahrenComponent.vue
+++ b/src/components/abfragevarianten/bauleitplanverfahren/CommonBauleitplanverfahrenComponent.vue
@@ -187,7 +187,7 @@ function datumSatzungsbeschlussChanged(): void {
         : datumSatzungsbeschluss.getFullYear() + 4;
   }
   isDialogBauratenLoeschenOpen.value =
-    originalSatzungsbeschluss != abfragevariante.value.satzungsbeschluss &&
+    originalSatzungsbeschluss.value != abfragevariante.value.satzungsbeschluss &&
     existsBauraten(abfragevariante.value.bauabschnitte);
 }
 

--- a/src/components/abfragevarianten/bauleitplanverfahren/CommonBauleitplanverfahrenComponent.vue
+++ b/src/components/abfragevarianten/bauleitplanverfahren/CommonBauleitplanverfahrenComponent.vue
@@ -180,7 +180,7 @@ function datumSatzungsbeschlussChanged(): void {
         ? datumSatzungsbeschluss.getFullYear() + 3
         : datumSatzungsbeschluss.getFullYear() + 4;
   }
-  isDialogBauratenLoeschenOpen.value = true;
+  isDialogBauratenLoeschenOpen.value = existsBauraten();
 }
 
 withDefaults(defineProps<Props>(), { isEditable: false });
@@ -197,7 +197,15 @@ function planartChanged(): void {
 }
 
 function realisierungVonChanged(): void {
-  isDialogBauratenLoeschenOpen.value = true;
+  isDialogBauratenLoeschenOpen.value = existsBauraten();
+}
+
+function existsBauraten(): boolean {
+  return (
+    abfragevariante.value.bauabschnitte?.some((bauabschnitt) =>
+      bauabschnitt.baugebiete?.some((baugebiet) => !_.isEmpty(baugebiet.bauraten)),
+    ) ?? false
+  );
 }
 
 function deleteBauraten(): void {

--- a/src/components/abfragevarianten/bauleitplanverfahren/CommonBauleitplanverfahrenComponent.vue
+++ b/src/components/abfragevarianten/bauleitplanverfahren/CommonBauleitplanverfahrenComponent.vue
@@ -30,7 +30,7 @@
           :disabled="!isEditable"
           label="Datum Satzungsbeschluss"
           month-picker
-          @focus="saveDatumSatzungsbeschluss"
+          @focus="saveSatzungsbeschluss"
           @blur="datumSatzungsbeschlussChanged"
           help="Erfolgt bei Datum 'Satzungsbeschluss' eine Eingabe, werden alle Bauraten gelöscht."
         />
@@ -204,7 +204,7 @@ function planartChanged(): void {
   }
 }
 
-function saveDatumSatzungsbeschluss(): void {
+function saveSatzungsbeschluss(): void {
   originalSatzungsbeschluss.value = abfragevariante.value.satzungsbeschluss;
 }
 

--- a/src/components/abfragevarianten/weiteresVerfahren/CommonWeiteresVerfahrenComponent.vue
+++ b/src/components/abfragevarianten/weiteresVerfahren/CommonWeiteresVerfahrenComponent.vue
@@ -94,6 +94,7 @@
           year
           maxlength="4"
           required
+          @focus="saveRealisierungVon"
           @blur="realisierungVonChanged"
           help="Erfolgt bei Datum 'Realisierung von' eine Eingabe, werden alle Bauraten gelöscht."
           :class="isEditable ? '' : 'text-grey-lighten-1'"
@@ -160,6 +161,8 @@ const { formChanged } = useSaveLeave();
 
 const isDialogBauratenLoeschenOpen = ref(false);
 
+const originalRealisierungVon = ref<number | null>();
+
 const wesentlicheRechtsgrundlageWeiteresVerfahrenList = computed(
   () => lookupStore.wesentlicheRechtsgrundlageWeiteresVerfahren,
 );
@@ -199,8 +202,14 @@ function wesentlicheRechtsgrundlageChanged(): void {
   }
 }
 
+function saveRealisierungVon(): void {
+  originalRealisierungVon.value = abfragevariante.value.realisierungVon;
+}
+
 function realisierungVonChanged(): void {
-  isDialogBauratenLoeschenOpen.value = existsBauraten(abfragevariante.value.bauabschnitte);
+  isDialogBauratenLoeschenOpen.value =
+    originalRealisierungVon.value != abfragevariante.value.realisierungVon &&
+    existsBauraten(abfragevariante.value.bauabschnitte);
 }
 
 function yesNoDialogBauratenLoeschenYes(): void {

--- a/src/components/abfragevarianten/weiteresVerfahren/CommonWeiteresVerfahrenComponent.vue
+++ b/src/components/abfragevarianten/weiteresVerfahren/CommonWeiteresVerfahrenComponent.vue
@@ -94,6 +94,8 @@
           year
           maxlength="4"
           required
+          @blur="realisierungVonChanged"
+          help="Erfolgt bei Datum Realisierung von eine Eingabe, werden alle Bauraten gelöscht."
           :class="isEditable ? '' : 'text-grey-lighten-1'"
         />
       </v-col>
@@ -113,6 +115,17 @@
       </v-col>
     </v-row>
   </field-group-card>
+  <yes-no-dialog
+    id="bauraten_loeschen_yes_no_dialog"
+    v-model="isDialogBauratenLoeschenOpen"
+    icon="mdi-delete-forever"
+    dialogtitle="Hinweis"
+    dialogtext="Hiermit werden alle Bauraten unwiderruflich gelöscht."
+    no-text="Abbrechen"
+    yes-text="Ändern"
+    @no="yesNoDialogBauratenLoeschenNo"
+    @yes="yesNoDialogBauratenLoeschenYes"
+  />
 </template>
 
 <script setup lang="ts">
@@ -128,6 +141,7 @@ import { useLookupStore } from "@/stores/LookupStore";
 import AbfragevarianteWeiteresVerfahrenModel from "@/types/model/abfragevariante/AbfragevarianteWeiteresVerfahrenModel";
 import { notUnspecified, pflichtfeld, pflichtfeldMehrfachauswahl } from "@/utils/FieldValidationRules";
 import _ from "lodash";
+import YesNoDialog from "@/components/common/YesNoDialog.vue";
 
 interface Props {
   isEditable?: boolean;
@@ -142,6 +156,8 @@ const wesentlicheRechtsgrundlageAngabenZurBefreiungVisible = ref<boolean | null>
 const lookupStore = useLookupStore();
 
 const { formChanged } = useSaveLeave();
+
+const isDialogBauratenLoeschenOpen = ref(false);
 
 const wesentlicheRechtsgrundlageWeiteresVerfahrenList = computed(
   () => lookupStore.wesentlicheRechtsgrundlageWeiteresVerfahren,
@@ -180,5 +196,26 @@ function wesentlicheRechtsgrundlageChanged(): void {
     abfragevariante.value.wesentlicheRechtsgrundlageAngabenZurBefreiung = undefined;
     wesentlicheRechtsgrundlageAngabenZurBefreiungVisible.value = false;
   }
+}
+
+function realisierungVonChanged(): void {
+  isDialogBauratenLoeschenOpen.value = true;
+}
+
+function deleteBauraten(): void {
+  abfragevariante.value.bauabschnitte?.forEach((bauabschnitt) => {
+    bauabschnitt.baugebiete.forEach((baugebiet) => {
+      baugebiet.bauraten = [];
+    });
+  });
+}
+
+function yesNoDialogBauratenLoeschenYes(): void {
+  deleteBauraten();
+  yesNoDialogBauratenLoeschenNo();
+}
+
+function yesNoDialogBauratenLoeschenNo(): void {
+  isDialogBauratenLoeschenOpen.value = false;
 }
 </script>

--- a/src/components/abfragevarianten/weiteresVerfahren/CommonWeiteresVerfahrenComponent.vue
+++ b/src/components/abfragevarianten/weiteresVerfahren/CommonWeiteresVerfahrenComponent.vue
@@ -95,7 +95,7 @@
           maxlength="4"
           required
           @blur="realisierungVonChanged"
-          help="Erfolgt bei Datum Realisierung von eine Eingabe, werden alle Bauraten gelöscht."
+          help="Erfolgt bei Datum 'Realisierung von' eine Eingabe, werden alle Bauraten gelöscht."
           :class="isEditable ? '' : 'text-grey-lighten-1'"
         />
       </v-col>
@@ -142,6 +142,7 @@ import AbfragevarianteWeiteresVerfahrenModel from "@/types/model/abfragevariante
 import { notUnspecified, pflichtfeld, pflichtfeldMehrfachauswahl } from "@/utils/FieldValidationRules";
 import _ from "lodash";
 import YesNoDialog from "@/components/common/YesNoDialog.vue";
+import { existsBauraten, deleteBauraten } from "@/utils/AbfragevarianteUtil";
 
 interface Props {
   isEditable?: boolean;
@@ -199,27 +200,11 @@ function wesentlicheRechtsgrundlageChanged(): void {
 }
 
 function realisierungVonChanged(): void {
-  isDialogBauratenLoeschenOpen.value = existsBauraten();
-}
-
-function existsBauraten(): boolean {
-  return (
-    abfragevariante.value.bauabschnitte?.some((bauabschnitt) =>
-      bauabschnitt.baugebiete?.some((baugebiet) => !_.isEmpty(baugebiet.bauraten)),
-    ) ?? false
-  );
-}
-
-function deleteBauraten(): void {
-  abfragevariante.value.bauabschnitte?.forEach((bauabschnitt) => {
-    bauabschnitt.baugebiete.forEach((baugebiet) => {
-      baugebiet.bauraten = [];
-    });
-  });
+  isDialogBauratenLoeschenOpen.value = existsBauraten(abfragevariante.value.bauabschnitte);
 }
 
 function yesNoDialogBauratenLoeschenYes(): void {
-  deleteBauraten();
+  deleteBauraten(abfragevariante.value.bauabschnitte);
   yesNoDialogBauratenLoeschenNo();
 }
 

--- a/src/components/abfragevarianten/weiteresVerfahren/CommonWeiteresVerfahrenComponent.vue
+++ b/src/components/abfragevarianten/weiteresVerfahren/CommonWeiteresVerfahrenComponent.vue
@@ -199,7 +199,15 @@ function wesentlicheRechtsgrundlageChanged(): void {
 }
 
 function realisierungVonChanged(): void {
-  isDialogBauratenLoeschenOpen.value = true;
+  isDialogBauratenLoeschenOpen.value = existsBauraten();
+}
+
+function existsBauraten(): boolean {
+  return (
+    abfragevariante.value.bauabschnitte?.some((bauabschnitt) =>
+      bauabschnitt.baugebiete?.some((baugebiet) => !_.isEmpty(baugebiet.bauraten)),
+    ) ?? false
+  );
 }
 
 function deleteBauraten(): void {

--- a/src/components/baugebiete/CommonRealisierungszeitraumComponent.vue
+++ b/src/components/baugebiete/CommonRealisierungszeitraumComponent.vue
@@ -17,6 +17,9 @@
           no-grouping
           required
           maxlength="4"
+          @focus="saveRealisierungVon"
+          @blur="realisierungVonChanged"
+          help="Erfolgt bei Datum 'Realisierung von' eine Eingabe, werden alle Bauraten gelöscht."
           :class="isEditable ? '' : 'text-grey-lighten-1'"
         />
       </v-col>
@@ -36,6 +39,17 @@
       </v-col>
     </v-row>
   </field-group-card>
+  <yes-no-dialog
+    id="bauraten_loeschen_yes_no_dialog"
+    v-model="isDialogBauratenLoeschenOpen"
+    icon="mdi-delete-forever"
+    dialogtitle="Hinweis"
+    dialogtext="Hiermit werden alle Bauraten unwiderruflich gelöscht."
+    no-text="Abbrechen"
+    yes-text="Ändern"
+    @no="yesNoDialogBauratenLoeschenNo"
+    @yes="yesNoDialogBauratenLoeschenYes"
+  />
 </template>
 
 <script setup lang="ts">
@@ -44,7 +58,9 @@ import FieldGroupCard from "@/components/common/FieldGroupCard.vue";
 import NumField from "@/components/common/NumField.vue";
 import BaugebietModel from "@/types/model/baugebiete/BaugebietModel";
 import _ from "lodash";
-import { computed } from "vue";
+import { computed, ref } from "vue";
+import { deleteBauraten, existsBauraten } from "@/utils/AbfragevarianteUtil";
+import YesNoDialog from "@/components/common/YesNoDialog.vue";
 
 interface Props {
   abfragevariante?: AnyAbfragevarianteDto;
@@ -53,6 +69,8 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), { isEditable: false });
 const baugebiet = defineModel<BaugebietModel>({ required: true });
+const originalRealisierungVon = ref<number | null>();
+const isDialogBauratenLoeschenOpen = ref(false);
 
 const calcRealisierungBis = computed(() => _.max(baugebiet.value.bauraten.map((baurate) => baurate.jahr)));
 
@@ -61,4 +79,21 @@ const abfragevarianteRealisierungVonOr1900 = computed(() => {
     ? props.abfragevariante.realisierungVon
     : 1900;
 });
+
+function saveRealisierungVon(): void {
+  originalRealisierungVon.value = baugebiet.value.realisierungVon;
+}
+
+function realisierungVonChanged(): void {
+  isDialogBauratenLoeschenOpen.value =
+    originalRealisierungVon.value != baugebiet.value.realisierungVon && !_.isEmpty(baugebiet.value.bauraten);
+}
+function yesNoDialogBauratenLoeschenYes(): void {
+  baugebiet.value.bauraten = [];
+  yesNoDialogBauratenLoeschenNo();
+}
+
+function yesNoDialogBauratenLoeschenNo(): void {
+  isDialogBauratenLoeschenOpen.value = false;
+}
 </script>

--- a/src/components/common/DatePicker.vue
+++ b/src/components/common/DatePicker.vue
@@ -13,6 +13,7 @@
         :hint="displayFormat"
         :readonly="disabled"
         :required="required"
+        @focus="focus()"
         @update:model-value="formChanged"
         @update:focused="$event || blur()"
         :class="disabled ? 'text-grey-lighten-1' : ''"
@@ -94,6 +95,7 @@ interface Props {
 
 interface Emits {
   (event: "blur", value: void): void;
+  (event: "focus", value: void): void;
 }
 
 const ISO_FORMAT = "YYYY-MM-DD";
@@ -198,6 +200,10 @@ function setTextFieldDateForMonthPicker(monthIndex: number): void {
 function deactivateDatePicker(): void {
   datePickerActive.value = false;
   blur();
+}
+
+function focus(): void {
+  emit("focus");
 }
 
 function blur(): void {

--- a/src/components/common/DatePicker.vue
+++ b/src/components/common/DatePicker.vue
@@ -28,6 +28,14 @@
         </template>
         <template #append>
           <v-icon v-bind="activatorProps">mdi-calendar</v-icon>
+          <template v-if="help">
+            <v-tooltip location="bottom">
+              <template #activator="{ props: helpActivatorProps }">
+                <v-icon v-bind="helpActivatorProps">mdi-help-circle-outline</v-icon>
+              </template>
+              <span>{{ help }}</span>
+            </v-tooltip>
+          </template>
         </template>
       </v-text-field>
     </template>
@@ -73,6 +81,7 @@ interface Props {
   disabled?: boolean; // Ob das Datumsfeld deaktiviert sein soll
   monthPicker?: boolean; // Ob nur Monat und Jahr auswählbar sein sollen
   rules?: Rule[]; // Welche Validierungsregeln gelten
+  help?: string;
 }
 
 interface Emits {

--- a/src/utils/AbfragevarianteUtil.ts
+++ b/src/utils/AbfragevarianteUtil.ts
@@ -1,4 +1,6 @@
 import { AnzeigeContextAbfragevariante, type AnyAbfragevarianteModel } from "@/types/common/Abfrage";
+import _ from "lodash";
+import BauabschnittModel from "@/types/model/bauabschnitte/BauabschnittModel";
 
 export function getAbfragevariantenNrForContextAnzeigeAbfragevariante(
   abfragevarianteModel: AnyAbfragevarianteModel,
@@ -11,4 +13,20 @@ export function getAbfragevariantenNrForContextAnzeigeAbfragevariante(
     numberContext = `2.${abfragevarianteModel.abfragevariantenNr}`;
   }
   return numberContext;
+}
+
+export function existsBauraten(bauabschnitte: BauabschnittModel[]): boolean {
+  return (
+    bauabschnitte?.some((bauabschnitt) =>
+      bauabschnitt.baugebiete?.some((baugebiet) => !_.isEmpty(baugebiet.bauraten)),
+    ) ?? false
+  );
+}
+
+export function deleteBauraten(bauabschnitte: BauabschnittModel[]): void {
+  bauabschnitte?.forEach((bauabschnitt) => {
+    bauabschnitt.baugebiete.forEach((baugebiet) => {
+      baugebiet.bauraten = [];
+    });
+  });
 }


### PR DESCRIPTION
**Description**

Umsetzung der Story [ISI2-120](https://jira.muenchen.de/browse/ISI2-120)

**Reference**

Issues #ISI2-120


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added confirmation dialogs when changing **“Datum Satzungsbeschluss”** or **“Realisierung von (JJJJ)”** to prevent accidental deletion of all *Bauraten*.
  * Date picker fields now support optional help text via a tooltip icon.
* **Behavior Change**
  * **“Idealtypische Bauraten ermitteln”** now also applies to technical/placeholder *bauabschnitte* setups, not only when *bauabschnitte* is empty.
  * Confirmation dialogs appear only when existing nested *bauraten* are present; confirming clears them, canceling keeps data unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->