### PR TITLE
ISI2-508-Verknuepfung-von-Abfrage-zu-Bauvorhaben-nicht-speicherbar

### DIFF
--- a/src/components/abfragen/baugenehmigungsverfahren/AllgemeineInformationenBaugenehmigungsverfahrenComponent.vue
+++ b/src/components/abfragen/baugenehmigungsverfahren/AllgemeineInformationenBaugenehmigungsverfahrenComponent.vue
@@ -148,7 +148,6 @@ import _ from "lodash";
 import AuswahlBauvorhabenDialog from "@/components/common/AuswahlBauvorhabenDialog.vue";
 import { useBauvorhabenApi } from "@/composables/requests/BauvorhabenApi";
 import { createBauvorhabenDto } from "@/utils/Factories";
-import DataTransferDialog from "@/components/common/DataTransferDialog.vue";
 
 interface Props {
   isEditable?: boolean;
@@ -171,7 +170,7 @@ const isBauverfahrenDeleteable = computed(() => {
   );
 });
 const nameBauvorhaben = computed(() => {
-  return !_.isEmpty(bauvorhaben.value.nameVorhaben) ? bauvorhaben.value.nameVorhaben : "Keinem Vorhaben zugeordnet";
+  return !_.isEmpty(bauvorhaben.value.nameVorhaben) ? bauvorhaben.value.nameVorhaben : "";
 });
 
 const appBase = `${window.location.origin}${window.location.pathname}`.replace(/\/+$/, "");

--- a/src/components/abfragen/baugenehmigungsverfahren/AllgemeineInformationenBaugenehmigungsverfahrenComponent.vue
+++ b/src/components/abfragen/baugenehmigungsverfahren/AllgemeineInformationenBaugenehmigungsverfahrenComponent.vue
@@ -35,35 +35,32 @@
       </v-col>
       <v-col
         cols="12"
-        md="4"
-        class="d-flex align-center"
+        md="3"
       >
-        <span v-if="vorhabenExists">
-          <a
-            target="_blank"
-            :href="linkVorhaben"
-          >
-            {{ nameBauvorhaben }}
-          </a>
-        </span>
-        <span
-          v-else-if="isBauverfahrenEditable"
-          class="v-label text-grey-lighten"
-        >
-          {{ nameBauvorhaben }}
-        </span>
-        <span
-          v-else
-          class="v-label text-grey-lighten-1"
-        >
-          {{ nameBauvorhaben }}
-        </span>
+        <v-text-field
+          id="vorhaben_field"
+          ref="vorhabenField"
+          v-model="nameBauvorhaben"
+          :readonly="true"
+          variant="underlined"
+          label="Vorhaben"
+          :class="isEditable ? '' : 'text-grey-lighten-1'"
+        />
       </v-col>
       <v-col
         cols="12"
-        md="2"
+        md="3"
       >
         <div class="d-flex align-center ml-8">
+          <v-btn
+            id="show_bauvorhaben"
+            class="mt-3"
+            variant="plain"
+            icon="mdi-eye-outline"
+            target="_blank"
+            :disabled="!vorhabenExists"
+            :href="linkVorhaben"
+          />
           <v-btn
             id="open_auswahl_bauvorhaben"
             class="mt-3"

--- a/src/components/abfragen/baugenehmigungsverfahren/AllgemeineInformationenBaugenehmigungsverfahrenComponent.vue
+++ b/src/components/abfragen/baugenehmigungsverfahren/AllgemeineInformationenBaugenehmigungsverfahrenComponent.vue
@@ -128,6 +128,7 @@
     id="auswahl_bauvorhaben_dialog"
     v-model="isAuswahlBauvorhabenDialogOpen"
     v-model:selected-bauvorhaben-id="abfrage.bauvorhaben"
+    @vorhaben-uebernehmen="vorhabenUebernehmen"
   />
 </template>
 
@@ -135,7 +136,11 @@
 import { ref, watch, computed } from "vue";
 import FieldGroupCard from "@/components/common/FieldGroupCard.vue";
 import BaugenehmigungsverfahrenModel from "@/types/model/abfrage/BaugenehmigungsverfahrenModel";
-import { BaugenehmigungsverfahrenDtoVerfahrensstandEnum, BauvorhabenDto } from "@/api/api-client/isi-backend";
+import {
+  AbfrageDto,
+  BaugenehmigungsverfahrenDtoVerfahrensstandEnum,
+  BauvorhabenDto,
+} from "@/api/api-client/isi-backend";
 import { pflichtfeld, notUnspecified } from "@/utils/FieldValidationRules";
 import { useLookupStore } from "@/stores/LookupStore";
 import { useSaveLeave } from "@/composables/SaveLeave";
@@ -146,6 +151,7 @@ import _ from "lodash";
 import AuswahlBauvorhabenDialog from "@/components/common/AuswahlBauvorhabenDialog.vue";
 import { useBauvorhabenApi } from "@/composables/requests/BauvorhabenApi";
 import { createBauvorhabenDto } from "@/utils/Factories";
+import DataTransferDialog from "@/components/common/DataTransferDialog.vue";
 
 interface Props {
   isEditable?: boolean;
@@ -228,4 +234,8 @@ const vorhabenExists = computed(() => {
 const linkVorhaben = computed(() => {
   return vorhabenExists.value ? `${appBase}/#/bauvorhaben/${encodeURIComponent(bauvorhaben.value.id as string)}` : "";
 });
+
+function vorhabenUebernehmen(value: string | undefined): void {
+  formChanged();
+}
 </script>

--- a/src/components/abfragen/bauleitplanverfahren/AllgemeineInformationenBauleitplanverfahrenComponent.vue
+++ b/src/components/abfragen/bauleitplanverfahren/AllgemeineInformationenBauleitplanverfahrenComponent.vue
@@ -19,40 +19,37 @@
       </v-col>
       <v-col
         cols="12"
-        md="4"
-        class="d-flex align-center"
+        md="3"
       >
-        <span v-if="vorhabenExists">
-          <a
-            target="_blank"
-            :href="linkVorhaben"
-          >
-            {{ nameBauvorhaben }}
-          </a>
-        </span>
-        <span
-          v-else-if="isBauverfahrenEditable"
-          class="v-label text-grey-lighten"
-        >
-          {{ nameBauvorhaben }}
-        </span>
-        <span
-          v-else
-          class="v-label text-grey-lighten-1"
-        >
-          {{ nameBauvorhaben }}
-        </span>
+        <v-text-field
+          id="vorhaben_field"
+          ref="vorhabenField"
+          v-model="nameBauvorhaben"
+          :readonly="true"
+          variant="underlined"
+          label="Vorhaben"
+          :class="isEditable ? '' : 'text-grey-lighten-1'"
+        />
       </v-col>
       <v-col
         cols="12"
-        md="2"
+        md="3"
       >
         <div class="d-flex align-center ml-8">
+          <v-btn
+            id="show_bauvorhaben"
+            class="mt-3"
+            variant="plain"
+            icon="mdi-eye-outline"
+            target="_blank"
+            :disabled="!vorhabenExists"
+            :href="linkVorhaben"
+          />
           <v-btn
             id="open_auswahl_bauvorhaben"
             variant="plain"
             class="mt-3"
-            :icon="isBauverfahrenEditable ? 'mdi-pencil-outline' : 'mdi-eye-outline'"
+            icon="mdi-pencil-outline"
             :disabled="!isBauverfahrenEditable"
             @click="isAuswahlBauvorhabenDialogOpen = true"
           />
@@ -244,7 +241,7 @@ const isBauverfahrenDeleteable = computed(() => {
   );
 });
 const nameBauvorhaben = computed(() => {
-  return !_.isEmpty(bauvorhaben.value.nameVorhaben) ? bauvorhaben.value.nameVorhaben : "Keinem Vorhaben zugeordnet";
+  return !_.isEmpty(bauvorhaben.value.nameVorhaben) ? bauvorhaben.value.nameVorhaben : "";
 });
 
 const appBase = `${window.location.origin}${window.location.pathname}`.replace(/\/+$/, "");

--- a/src/components/abfragen/bauleitplanverfahren/AllgemeineInformationenBauleitplanverfahrenComponent.vue
+++ b/src/components/abfragen/bauleitplanverfahren/AllgemeineInformationenBauleitplanverfahrenComponent.vue
@@ -197,6 +197,7 @@
     id="auswahl_bauvorhaben_dialog"
     v-model="isAuswahlBauvorhabenDialogOpen"
     v-model:selected-bauvorhaben-id="abfrage.bauvorhaben"
+    @vorhaben-uebernehmen="vorhabenUebernehmen"
   />
 </template>
 
@@ -326,4 +327,8 @@ const vorhabenExists = computed(() => {
 const linkVorhaben = computed(() => {
   return vorhabenExists.value ? `${appBase}/#/bauvorhaben/${encodeURIComponent(bauvorhaben.value.id as string)}` : "";
 });
+
+function vorhabenUebernehmen(value: string | undefined): void {
+  formChanged();
+}
 </script>

--- a/src/components/abfragen/weiteresVerfahren/AllgemeineInformationenWeiteresVerfahrenComponent.vue
+++ b/src/components/abfragen/weiteresVerfahren/AllgemeineInformationenWeiteresVerfahrenComponent.vue
@@ -38,32 +38,30 @@
         md="4"
         class="d-flex align-center"
       >
-        <span v-if="vorhabenExists">
-          <a
-            target="_blank"
-            :href="linkVorhaben"
-          >
-            {{ nameBauvorhaben }}
-          </a>
-        </span>
-        <span
-          v-else-if="isBauverfahrenEditable"
-          class="v-label text-grey-lighten"
-        >
-          {{ nameBauvorhaben }}
-        </span>
-        <span
-          v-else
-          class="v-label text-grey-lighten-1"
-        >
-          {{ nameBauvorhaben }}
-        </span>
+        <v-text-field
+          id="vorhaben_field"
+          ref="vorhabenField"
+          v-model="nameBauvorhaben"
+          :readonly="true"
+          variant="underlined"
+          label="Vorhaben"
+          :class="isEditable ? '' : 'text-grey-lighten-1'"
+        />
       </v-col>
       <v-col
         cols="12"
         md="2"
       >
         <div class="d-flex align-center ml-8">
+          <v-btn
+            id="show_bauvorhaben"
+            class="mt-3"
+            variant="plain"
+            icon="mdi-eye-outline"
+            target="_blank"
+            :disabled="!vorhabenExists"
+            :href="linkVorhaben"
+          />
           <v-btn
             id="open_auswahl_bauvorhaben"
             class="mt-3"
@@ -217,7 +215,7 @@ const isBauverfahrenDeleteable = computed(() => {
   );
 });
 const nameBauvorhaben = computed(() => {
-  return !_.isEmpty(bauvorhaben.value.nameVorhaben) ? bauvorhaben.value.nameVorhaben : "Keinem Vorhaben zugeordnet";
+  return !_.isEmpty(bauvorhaben.value.nameVorhaben) ? bauvorhaben.value.nameVorhaben : "";
 });
 
 const appBase = `${window.location.origin}${window.location.pathname}`.replace(/\/+$/, "");

--- a/src/components/abfragen/weiteresVerfahren/AllgemeineInformationenWeiteresVerfahrenComponent.vue
+++ b/src/components/abfragen/weiteresVerfahren/AllgemeineInformationenWeiteresVerfahrenComponent.vue
@@ -170,6 +170,7 @@
     id="auswahl_bauvorhaben_dialog"
     v-model="isAuswahlBauvorhabenDialogOpen"
     v-model:selected-bauvorhaben-id="abfrage.bauvorhaben"
+    @vorhaben-uebernehmen="vorhabenUebernehmen"
   />
 </template>
 
@@ -289,4 +290,8 @@ const vorhabenExists = computed(() => {
 const linkVorhaben = computed(() => {
   return vorhabenExists.value ? `${appBase}/#/bauvorhaben/${encodeURIComponent(bauvorhaben.value.id as string)}` : "";
 });
+
+function vorhabenUebernehmen(value: string | undefined): void {
+  formChanged();
+}
 </script>

--- a/src/components/common/AuswahlBauvorhabenDialog.vue
+++ b/src/components/common/AuswahlBauvorhabenDialog.vue
@@ -88,8 +88,14 @@ import {
   type StadtbezirkDto,
   SearchQueryAndSortingDtoSortByEnum,
   SearchQueryAndSortingDtoSortOrderEnum,
+  type AbfrageDto,
+  BauvorhabenDto,
 } from "@/api/api-client/isi-backend";
 import { useSearchApi } from "@/composables/requests/search/SearchApi";
+
+interface Emits {
+  (event: "vorhabenUebernehmen", value: BauvorhabenDto): void;
+}
 
 type ResultItem = {
   label: string;
@@ -111,6 +117,8 @@ const pendingSelectedBauvorhabenId = ref<string | undefined>(undefined);
 const pendingSelectedLabel = ref<string>("");
 
 const loading = ref(false);
+
+const emit = defineEmits<Emits>();
 
 let currentSearchRequestId = 0;
 let isComponentActive = true;
@@ -328,6 +336,7 @@ function uebernehmen(): void {
 
   selectedBauvorhabenId.value = pendingSelectedBauvorhabenId.value;
   dialogOpen.value = false;
+  emit("vorhabenUebernehmen", selectedBauvorhabenId.value);
 }
 
 /**


### PR DESCRIPTION
Behebung des Bugs #ISI2-508

**Description**

_Aktualisieren_ Button ist aktiv, wenn ein Vorhaben einer Abfrage zugeordnet wird. Nach _Aktualisieren_ ist das ausgewählte Vorhaben der Abfrage zugeordnet.

**Reference**

Issues #ISI2-508


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Confirming a construction project selection now consistently marks the related forms as changed.
  * Improved “Vorhaben” value propagation across construction, development planning, and other procedure forms.
* **Enhancements**
  * Updated the “Vorhaben” display to a read-only input field and standardized how the selected value is emitted and handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->