### PR TITLE
ISI2-793-Layer-Flurstuecke-nicht-darstellbar

### DIFF
--- a/src/utils/MapUtil.ts
+++ b/src/utils/MapUtil.ts
@@ -163,7 +163,8 @@ export function assembleBaseLayersForLayerControl(): Record<string, TileLayer.WM
   }
 
   for (const overlay of OVERLAYS_GRUNDKARTE) {
-    const layer = L.nonTiledLayer.wms(getArcgisUrl("Grundkarten"), {
+    const url = import.meta.env.VITE_ARCGIS_URL as string;
+    const layer = L.nonTiledLayer.wms(getArcgisUrl(url, "Grundkarten"), {
       layers: overlay[1],
       transparent: true,
       ...LAYER_OPTIONS,


### PR DESCRIPTION
**Description**

Bugfix #ISI2-793

**Reference**

Issues #ISI2-793


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved construction of ArcGIS WMS URLs for base map layers, helping ensure they load from the configured service endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->